### PR TITLE
support custom/non-global fetch implementation

### DIFF
--- a/demo/PetstoreApi.ts
+++ b/demo/PetstoreApi.ts
@@ -19,18 +19,22 @@ type JsonRequestOpts = RequestOpts & {
 type MultipartRequestOpts = RequestOpts & {
     body: Record<string, string | Blob | undefined | any>;
 };
+export type ApiOptions = {
+    baseUrl?: string;
+    fetch?: typeof fetch;
+} & RequestInit;
 export class Api {
     private _baseUrl: string;
+    private _fetchImpl?: typeof fetch;
     private _fetchOpts: RequestInit;
-    constructor({ baseUrl = "https://petstore.swagger.io/v2", ...fetchOpts }: {
-        baseUrl?: string;
-    } & RequestInit = {}) {
+    constructor({ baseUrl = "https://petstore.swagger.io/v2", fetch: fetchImpl, ...fetchOpts }: ApiOptions = {}) {
+        this._fetchImpl = fetchImpl;
         this._baseUrl = baseUrl;
         this._fetchOpts = fetchOpts;
     }
     private async _fetch(url: string, req: FetchRequestOpts = {}) {
         const headers = stripUndefined(req.headers);
-        const res = await fetch(this._baseUrl + url, {
+        const res = await (this._fetchImpl || fetch)(this._baseUrl + url, {
             ...this._fetchOpts,
             ...req,
             headers

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
       "ts",
       "d.ts"
     ],
+    "restoreMocks": true,
     "transform": {
       "\\.ts$": "ts-jest"
     }

--- a/src/ApiStub.test.ts
+++ b/src/ApiStub.test.ts
@@ -1,5 +1,41 @@
-import { QS } from "./ApiStub";
+import { QS, Api, ApiOptions } from "./ApiStub";
 const { query, pipe, form, space, deep, explode } = QS;
+
+describe("Api", () => {
+  const createApi = (options: ApiOptions) => {
+    return (new Api(options) as any)
+  }
+  let g: any;
+
+  beforeAll(() => {
+    g = (global as any);
+    g.fetch = g.fetch || (() => {});
+  });
+
+  it("should use global fetch", () => {
+    jest.spyOn(g, "fetch").mockImplementationOnce(() => ({
+      ok: true,
+      text: () => "hello"
+    }));
+
+    createApi({ baseUrl: "foo/" })._fetch("bar", {})
+
+    expect(g.fetch).toHaveBeenCalledWith('foo/bar', expect.any(Object));
+  });
+
+  it("should not use global fetch if local is provided", () => {
+    jest.spyOn(g, "fetch");
+    const customFetch = jest.fn(() => ({
+      ok: true,
+      text: () => "hello"
+    }) as any);
+
+    createApi({ baseUrl: "foo/", fetch: customFetch })._fetch("bar", {})
+
+    expect(customFetch).toHaveBeenCalledWith('foo/bar', expect.any(Object));
+    expect(g.fetch).not.toHaveBeenCalled();
+  });
+});
 
 describe("delimited", () => {
   it("should use commas", () => {

--- a/src/ApiStub.ts
+++ b/src/ApiStub.ts
@@ -26,21 +26,29 @@ type MultipartRequestOpts = RequestOpts & {
   body: Record<string, string | Blob | undefined | any>;
 };
 
+export type ApiOptions = {
+  baseUrl?: string,
+  fetch?: typeof fetch
+} & RequestInit;
+
 export class Api {
   private _baseUrl: string;
+  private _fetchImpl?: typeof fetch;
   private _fetchOpts: RequestInit;
 
   constructor({
     baseUrl = "",
+    fetch: fetchImpl,
     ...fetchOpts
-  }: { baseUrl?: string } & RequestInit = {}) {
+  }: ApiOptions = {}) {
+    this._fetchImpl = fetchImpl;
     this._baseUrl = baseUrl;
     this._fetchOpts = fetchOpts;
   }
 
   private async _fetch(url: string, req: FetchRequestOpts = {}) {
     const headers = stripUndefined(req.headers);
-    const res = await fetch(this._baseUrl + url, {
+    const res = await (this._fetchImpl || fetch)(this._baseUrl + url, {
       ...this._fetchOpts,
       ...req,
       headers


### PR DESCRIPTION
in order not not rely on a globally available fetch, support easier mocking, etc.