### PR TITLE
feat(generate): create Server classes from API servers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,1 @@
+{ "editor.formatOnSave": false }

--- a/demo/PetstoreApi.ts
+++ b/demo/PetstoreApi.ts
@@ -19,17 +19,30 @@ type JsonRequestOpts = RequestOpts & {
 type MultipartRequestOpts = RequestOpts & {
     body: Record<string, string | Blob | undefined | any>;
 };
+type ServerI = {
+    url: string;
+};
 export type ApiOptions = {
+    /**
+     * @deprecated "baseUrl" has been renamed to "server"
+     */
     baseUrl?: string;
+    server?: ServerI | string;
     fetch?: typeof fetch;
 } & RequestInit;
+function getUrl(server: string | ServerI): string {
+    if (typeof server === "string") {
+        return server;
+    }
+    return server.url;
+}
 export class Api {
     private _baseUrl: string;
     private _fetchImpl?: typeof fetch;
     private _fetchOpts: RequestInit;
-    constructor({ baseUrl = "https://petstore.swagger.io/v2", fetch: fetchImpl, ...fetchOpts }: ApiOptions = {}) {
+    constructor({ baseUrl = "https://petstore.swagger.io/v2", server, fetch: fetchImpl, ...fetchOpts }: ApiOptions = {}) {
         this._fetchImpl = fetchImpl;
-        this._baseUrl = baseUrl;
+        this._baseUrl = server ? getUrl(server) : baseUrl;
         this._fetchOpts = fetchOpts;
     }
     private async _fetch(url: string, req: FetchRequestOpts = {}) {
@@ -411,3 +424,15 @@ export type User = {
     phone?: string;
     userStatus?: number;
 };
+export class Server {
+    url: string;
+    constructor() {
+        this.url = "https://petstore.swagger.io/v2";
+    }
+}
+export class Server2 {
+    url: string;
+    constructor() {
+        this.url = "http://petstore.swagger.io/v2";
+    }
+}

--- a/src/ApiStub.ts
+++ b/src/ApiStub.ts
@@ -26,10 +26,26 @@ type MultipartRequestOpts = RequestOpts & {
   body: Record<string, string | Blob | undefined | any>;
 };
 
+type ServerI = {
+  url: string;
+}
+
 export type ApiOptions = {
-  baseUrl?: string,
-  fetch?: typeof fetch
+  /**
+   * @deprecated "baseUrl" has been renamed to "server"
+   */
+  baseUrl?: string;
+  server?: ServerI | string;
+  fetch?: typeof fetch;
 } & RequestInit;
+
+function getUrl(server: string | ServerI): string {
+  if (typeof server === 'string') {
+    return server;
+  }
+
+  return server.url;
+}
 
 export class Api {
   private _baseUrl: string;
@@ -38,11 +54,12 @@ export class Api {
 
   constructor({
     baseUrl = "",
+    server,
     fetch: fetchImpl,
     ...fetchOpts
   }: ApiOptions = {}) {
     this._fetchImpl = fetchImpl;
-    this._baseUrl = baseUrl;
+    this._baseUrl = server ? getUrl(server) : baseUrl;
     this._fetchOpts = fetchOpts;
   }
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import path from "path";
 import * as oapi from "@loopback/openapi-v3-types";
 import * as cg from "./tscodegen";
+import generateServers from './generateServers';
 
 const verbs = [
   "GET",
@@ -508,7 +509,10 @@ export default function generateApi(spec: oapi.OpenApiSpec) {
     });
   });
 
-  stub.statements = cg.appendNodes(stub.statements, ...aliases);
+  stub.statements = cg.appendNodes(stub.statements, ...[
+    ...aliases,
+    ...generateServers(spec.servers || [])
+  ]);
   apiClass.members = cg.appendNodes(apiClass.members, ...members);
 
   return stub;

--- a/src/generateServers.test.ts
+++ b/src/generateServers.test.ts
@@ -1,0 +1,69 @@
+import generateServers from './generateServers';
+import * as cg from "./tscodegen";
+
+function normalize(str: string) {
+  return str.trim().replace(/\n|\r|\n\r/g, '\n ').replace(/ +/g, ' ')
+}
+
+describe('generateServer', () => {
+  it('creates a Server class', () => {
+    const servers = generateServers([{ url: 'http://example.org' }]);
+
+    expect(normalize(cg.printNodes(servers)))
+      .toBe(normalize(`export class Server {
+        url: string;
+        constructor() {
+          this.url = \"http://example.org\";
+        }
+      }`));
+  });
+
+  it('creates Server classes with Names', () => {
+    const servers = generateServers([
+      { url: 'http://example.org', description: "Super API" },
+      { url: 'http://example.org/2' },
+    ]);
+
+    expect(normalize(cg.printNodes(servers)))
+      .toBe(normalize(`
+        export class SuperApiServer {
+          url: string;
+          constructor() {
+            this.url = \"http://example.org\";
+          }
+        }
+        export class Server2 {
+          url: string;
+          constructor() {
+            this.url = \"http://example.org/2\";
+          }
+        }
+      `));
+  });
+
+  it('creates a Server with variables', () => {
+    const servers = generateServers([{
+      variables: {
+        tld: {
+          enum: ['org', 'com'],
+          default: 'org'
+        },
+        path: {
+          default: ''
+        }
+      },
+      url: 'http://example.{tld}/{path}'
+    }]);
+
+    expect(normalize(cg.printNodes(servers)))
+      .toBe(normalize(`export class Server {
+        url: string;
+        constructor({ tld = "org", path = "" }: {
+          tld: "org" | "com";
+          path: string | number | boolean;
+        }) {
+          this.url = \`http://example.\${tld}/\${path}\`;
+        }
+      }`));
+  })
+});

--- a/src/generateServers.ts
+++ b/src/generateServers.ts
@@ -1,0 +1,91 @@
+import _ from 'lodash';
+import * as oapi from "@loopback/openapi-v3-types";
+import * as cg from "./tscodegen";
+import ts, { TypeNode, ParameterDeclaration, LiteralExpression, Expression, TemplateLiteral } from "typescript";
+
+function createLiteral(v: string | boolean | number) {
+  switch (typeof v) {
+    case 'string':
+      return ts.createStringLiteral(v);
+    case 'boolean':
+      return v ? ts.createTrue() : ts.createFalse();
+    case 'number':
+      return ts.createNumericLiteral(String(v));
+  }
+}
+
+function createUnion(strs: (string | boolean | number)[]): TypeNode[] {
+  return strs.map((e): TypeNode => {
+    return ts.createLiteralTypeNode(createLiteral(e));
+  });
+}
+
+function createTemplate(server: oapi.ServerObject): TemplateLiteral {
+  const tokens = server.url.split(/{([\s\S]+?)}/g);
+  const chunks = _.chunk(tokens.slice(1), 2);
+  return ts.createTemplateExpression(
+    ts.createTemplateHead(tokens[0]),
+    [...chunks.map(([expression, literal], i) => {
+      return ts.createTemplateSpan(
+        ts.createIdentifier(expression),
+        (i === chunks.length -1 ? ts.createTemplateTail : ts.createTemplateMiddle)(literal)
+      )
+    })]
+  )
+}
+
+export default function generateServers(servers: oapi.ServerObject[]) {
+  return servers.map((server, i) => {
+    const name: string = server.description ?
+      _.upperFirst(_.camelCase(`${server.description.replace(/\W+/, ' ')} Server`)) :
+      `Server${i === 0 ? '' : String(i + 1)}`;
+
+    return cg.createClassDeclaration({
+      name,
+      modifiers: [cg.modifier.export],
+      members: [
+        ts.createProperty(undefined, undefined, 'url', undefined, cg.keywordType.string, undefined),
+        cg.createConstructor({
+          parameters: server.variables ? [cg.createParameter(
+            cg.createObjectBinding(Object.entries((server.variables || {})).map(
+              ([name, value]) => {
+                return {
+                  name,
+                  initializer: createLiteral(value.default)
+                }
+              }
+            )),
+            {
+              type: ts.createTypeLiteralNode(Object.entries((server.variables || {})).map(
+                ([name, value]) => {
+                  return cg.createPropertySignature({
+                    name,
+                    type: value.enum ?
+                      ts.createUnionTypeNode(createUnion(value.enum)) :
+                      ts.createUnionTypeNode([
+                        cg.keywordType.string,
+                        cg.keywordType.number,
+                        cg.keywordType.boolean
+                      ])
+                  });
+                }
+              ))
+            }
+          )] : [],        
+          body: cg.block(
+            ts.createExpressionStatement(
+              ts.createBinary(
+                ts.createPropertyAccess(
+                  ts.createThis(),
+                  ts.createIdentifier('url')
+                ),
+                ts.SyntaxKind.EqualsToken,
+                server.variables ? createTemplate(server) : ts.createStringLiteral(server.url)
+              )
+            )
+          )
+        })
+      ]
+    })
+  });
+}


### PR DESCRIPTION
in order to expose all potential URLs and variables of the apis servers.

Given swagger spec:

```json
{
  "servers": [
    {
      "description": "MyApi",
      "url": "https://petstore.swagger.io/{version}",
      "variables": {
        "version": {
          "enum": ["v1", "v2"],
          "default": "v2"
        }
      }
    }
  ]
}
```

Usage:

```ts
import { Api, MyApiServer } from './Api.ts';

const api = new Api({ server: new MyApiServer({ version: "v1" }) });
```

I deprecated `ApiOptions["baseUrl"]` in favour of `ApiOptions["server"]` which can either be a string or an object with url prop.

PTAL: @fgnass 