### PR TITLE
fix: don't add an index to arrays

### DIFF
--- a/demo/PetstoreApi.ts
+++ b/demo/PetstoreApi.ts
@@ -339,10 +339,14 @@ export const QS = {
     deep(params: Record<string, any>, [k, v] = encodeReserved): string {
         const qk = encode([s => s, k]);
         const qv = encode([s => s, v]);
+        // don't add index to arrays
+        // https://github.com/expressjs/body-parser/issues/289
         const visit = (obj: any, prefix = ""): string => Object.entries(obj)
             .filter(([, v]) => v !== undefined)
             .map(([prop, v]) => {
-            const key = prefix ? qk `${prefix}[${prop}]` : prop;
+            const index = Array.isArray(obj) ? "" : prop;
+            const key = prefix
+                ? qk `${prefix}[${index}]` : prop;
             if (typeof v === "object") {
                 return visit(v, key);
             }

--- a/src/ApiStub.test.ts
+++ b/src/ApiStub.test.ts
@@ -87,6 +87,11 @@ describe("deep", () => {
       "author[name]=Felix"
     );
   });
+  it("should serialize nested arrays", () => {
+    expect(deep({ names: ["Felix", "Dario"] })).toEqual(
+      "names[]=Felix&names[]=Dario"
+    );
+  });
 });
 
 describe("query", () => {

--- a/src/ApiStub.ts
+++ b/src/ApiStub.ts
@@ -189,13 +189,17 @@ export const QS = {
   deep(params: Record<string, any>, [k, v] = encodeReserved): string {
     const qk = encode([s => s, k]);
     const qv = encode([s => s, v]);
-    const visit = (obj: any, prefix = ""): string =>
+    // don't add index to arrays
+    // https://github.com/expressjs/body-parser/issues/289
+    const visit = (obj: any, prefix = "", noIndex = false): string =>
       Object.entries(obj)
         .filter(([, v]) => v !== undefined)
         .map(([prop, v]) => {
-          const key = prefix ? qk`${prefix}[${prop}]` : prop;
+          const key = prefix
+            ? noIndex ? prefix : qk`${prefix}[${prop}]`
+            : prop;
           if (typeof v === "object") {
-            return visit(v, key);
+            return visit(v, key, Array.isArray(v));
           }
           return qv`${key}=${v}`;
         })

--- a/src/ApiStub.ts
+++ b/src/ApiStub.ts
@@ -191,15 +191,15 @@ export const QS = {
     const qv = encode([s => s, v]);
     // don't add index to arrays
     // https://github.com/expressjs/body-parser/issues/289
-    const visit = (obj: any, prefix = "", noIndex = false): string =>
+    const visit = (obj: any, prefix = ""): string =>
       Object.entries(obj)
         .filter(([, v]) => v !== undefined)
         .map(([prop, v]) => {
+          const index = Array.isArray(obj) ? "" : prop;
           const key = prefix
-            ? noIndex ? prefix : qk`${prefix}[${prop}]`
-            : prop;
+            ? qk`${prefix}[${index}]` : prop;
           if (typeof v === "object") {
-            return visit(v, key, Array.isArray(v));
+            return visit(v, key);
           }
           return qv`${key}=${v}`;
         })


### PR DESCRIPTION
Since this can lead to problems when parsing the query. See https://github.com/expressjs/body-parser/issues/289.