### PR TITLE
fix: Use process exitCode instead of exit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ const [, , spec, dest] = process.argv;
 
 if (!spec) {
   console.error("Usage: oazapfts <spec> [filename]");
-  process.exit(1);
+  process.exitCode = 1;
+} else {
+  generate(spec, dest);
 }
-
-generate(spec, dest);


### PR DESCRIPTION
One small detail I noticed and tough could be interesting to tweak was the exit usage. 

Check https://eslint.org/docs/rules/no-process-exit for more details.