### PR TITLE
Allow external refs

### DIFF
--- a/demo/extern.yaml
+++ b/demo/extern.yaml
@@ -1,0 +1,14 @@
+PartnerInfo:
+  type: object
+  required:
+    - name
+  properties:
+    name:
+      type: string
+    flavor:
+      type: string
+    bestBeforeDate:
+      type: string
+      format: date
+    numInPack:
+      type: integer

--- a/demo/full.yaml
+++ b/demo/full.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.1
+
+info:
+  title: awesome corporate api
+  version: 0.0.0
+
+paths:
+  /partners:
+    post:
+      operationId: createPartner
+      description: >-
+        create a new partner
+
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePartnerRequest'
+      responses:
+        # XXX: should be 202?
+        200:
+          $ref: '#/components/responses/AnyResponse'
+
+components:
+  schemas:
+    Any:
+      description: fake stub obj
+      type: object
+
+    PartnerInfo:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        flavor:
+          type: string
+        bestBeforeDate:
+          type: string
+          format: date
+        numInPack:
+          type: integer
+
+  requestBodies:
+    CreatePartnerRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PartnerInfo'
+
+  responses:
+    AnyResponse:
+      description: eat shit
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Any'

--- a/demo/with-extern.yaml
+++ b/demo/with-extern.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+
+info:
+  title: awesome corporate api
+  version: 0.0.0
+
+paths:
+  /partners:
+    post:
+      operationId: createPartner
+      description: >-
+        create a new partner
+
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePartnerRequest'
+      responses:
+        # XXX: should be 202?
+        200:
+          $ref: '#/components/responses/AnyResponse'
+
+components:
+  schemas:
+    Any:
+      description: fake stub obj
+      type: object
+
+    PartnerInfo:
+      $ref: './extern.yaml#/PartnerInfo'
+
+  requestBodies:
+    CreatePartnerRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PartnerInfo'
+
+  responses:
+    AnyResponse:
+      description: eat shit
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Any'

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export function printAst(ast: ts.SourceFile) {
 
 export async function generateSource(spec: string) {
   let v3Doc;
-  const doc = await SwaggerParser.parse(spec);
+  const doc = await SwaggerParser.bundle(spec);
   const isOpenApiV3 = "openapi" in doc && doc.openapi.startsWith("3");
   if (isOpenApiV3) {
     v3Doc = doc as OpenAPIV3.Document;


### PR DESCRIPTION
PR for issue #21 

In theory this is just the tiny change from `parse` to `bundle`. It appears that this is what we want to do from [their documentation](https://apitools.dev/swagger-parser/docs/swagger-parser.html#bundleapi-options-callback):

> Bundles all referenced files/URLs into a single api that only has internal $ref pointers. This lets you split-up your API however you want while you’re building it, but easily combine all those files together when it’s time to package or distribute the API to other people. The resulting API size will be small, since it will still contain internal JSON references rather than being fully-dereferenced.

I've also included the test cases I used to implement them. As you see, there are 2 yaml files, one of which has 1 fragment moved to a third yaml file. The resulting output was identical.

I would have liked to add a test to verify this, although I had a small problem. When I ran tests, it modified `demo/api.ts` such that the indentation was increase from 2 spaces to 4. I don't know why this happened. It wasn't related to this change; running the tests on a clean repo (deps installed with `npm ci`) made the same change on my machine.