### PR TITLE
docs: omit reference to official tooling from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Generate TypeScript clients to tap into OpenAPI servers.
 
 - **AST-based**:
   Unlike other code generators `oazapfts` does not use templates to generate code but uses TypeScript's built-in API to generate and pretty-print an abstract syntax tree.
-- **Fast**: The cli does not use any of the official Java-based tooling, so the code generation is super fast.
+- **Fast**: The cli does not use any of the common Java-based tooling, so the code generation is super fast.
 - **Tree-shakeable**: Individually exported functions allow you to bundle only the ones you actually use.
 - **Human friendly signatures**: The generated api methods don't leak an HTTP-specific implementation details. For example, all optional parameters are grouped together in one object, no matter whether they end up in the headers, path or query-string.
 


### PR DESCRIPTION
There is no official OpenAPI tooling (though there are two popular open-source Java-based tools).