### PR TITLE
fix: generate boolean values in enum

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -29,6 +29,7 @@ export type Pet = {
     photoUrls: string[];
     tags?: Tag[];
     status?: "available" | "pending" | "sold";
+    animal?: true;
 };
 export type ApiResponse = {
     code?: number;

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -29,6 +29,7 @@ export type Pet = {
     photoUrls: string[];
     tags?: Tag[];
     status?: "available" | "pending" | "sold";
+    animal?: true;
 };
 export type ApiResponse = {
     code?: number;

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1053,6 +1053,13 @@
             "type": "string",
             "description": "pet status in the store",
             "enum": ["available", "pending", "sold"]
+          },
+          "animal": {
+            "description": "Always true for a pet",
+            "enum": [
+              true
+            ],
+            "type": "boolean"
           }
         },
         "xml": {

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -361,11 +361,11 @@ export default function generateApi(spec: OpenAPIV3.Document, opts?: Opts) {
     }
     if (schema.enum) {
       // enum -> union of literal types
-      const types = schema.enum.map((s) =>
-        s === null
-          ? cg.keywordType.null
-          : ts.createLiteralTypeNode(ts.createStringLiteral(s))
-      );
+      const types = schema.enum.map((s) => {
+        if (s === null) return cg.keywordType.null;
+        if (typeof s === "boolean") return s ? ts.createTrue() : ts.createFalse();
+        return ts.createLiteralTypeNode(ts.createStringLiteral(s));
+      });
       return types.length > 1 ? ts.createUnionTypeNode(types) : types[0];
     }
     if (schema.format == "binary") {


### PR DESCRIPTION
When having boolean values in an enum, the code generation fails.

**Enum boolean property in OpenAPI document:**
```json
{
  "animal": {
    "description": "Always true for a pet",
    "enum": [
      true
    ],
    "type": "boolean"
  }
}
```

**Error:**
```
TypeError: s.replace is not a function

at escapeString (../node_modules/typescript/lib/typescript.js:16266:18)
at escapeNonAsciiString (../node_modules/typescript/lib/typescript.js:16271:13)
at Object.getLiteralText (../node_modules/typescript/lib/typescript.js:13486:34)
at getLiteralTextOfNode (../node_modules/typescript/lib/typescript.js:98322:23)
at emitLiteral (../node_modules/typescript/lib/typescript.js:95932:24)
at pipelineEmitWithHint (../node_modules/typescript/lib/typescript.js:95744:32)
at pipelineEmitWithComments (../node_modules/typescript/lib/typescript.js:98730:17)
at pipelineEmit (../node_modules/typescript/lib/typescript.js:95382:13)
at emitExpression (../node_modules/typescript/lib/typescript.js:95367:20)
at emitLiteralType (../node_modules/typescript/lib/typescript.js:96310:13)
```

This PR fixes that issue and outputs the correct type.