### PR TITLE
fix: respect requestBody required property

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -146,7 +146,7 @@ export function getPetById(petId: number, opts?: Oazapfts.RequestOpts) {
 /**
  * Updates a pet in the store with form data
  */
-export function updatePetWithForm(petId: number, body: {
+export function updatePetWithForm(petId: number, body?: {
     name?: string;
     status?: string;
 }, opts?: Oazapfts.RequestOpts) {
@@ -174,7 +174,7 @@ export function deletePet(petId: number, { apiKey }: {
 /**
  * uploads an image
  */
-export function uploadFile(petId: number, body: {
+export function uploadFile(petId: number, body?: {
     additionalMetadata?: string;
     file?: Blob;
 }, opts?: Oazapfts.RequestOpts) {

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -146,7 +146,7 @@ export function getPetById(petId: number, opts?: Oazapfts.RequestOpts) {
 /**
  * Updates a pet in the store with form data
  */
-export function updatePetWithForm(petId: number, body: {
+export function updatePetWithForm(petId: number, body?: {
     name?: string;
     status?: string;
 }, opts?: Oazapfts.RequestOpts) {
@@ -174,7 +174,7 @@ export function deletePet(petId: number, { apiKey }: {
 /**
  * uploads an image
  */
-export function uploadFile(petId: number, body: {
+export function uploadFile(petId: number, body?: {
     additionalMetadata?: string;
     file?: Blob;
 }, opts?: Oazapfts.RequestOpts) {

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -579,6 +579,7 @@ export default function generateApi(spec: OpenAPIV3.Document, opts?: Opts) {
         methodParams.push(
           cg.createParameter(bodyVar, {
             type,
+            questionToken: !body.required
           })
         );
       }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -13,13 +13,13 @@ type FetchRequestOpts = RequestOpts & {
 };
 
 type JsonRequestOpts = RequestOpts & {
-  body: object;
+  body?: object;
 };
 
 export type ApiResponse = { status: number; data?: any };
 
 type MultipartRequestOpts = RequestOpts & {
-  body: Record<string, string | Blob | undefined | any>;
+  body?: Record<string, string | Blob | undefined | any>;
 };
 
 export function runtime(defaults: RequestOpts) {
@@ -70,7 +70,7 @@ export function runtime(defaults: RequestOpts) {
     json({ body, headers, ...req }: JsonRequestOpts) {
       return {
         ...req,
-        body: JSON.stringify(body),
+        ...(body && { body: JSON.stringify(body) }),
         headers: {
           ...headers,
           "Content-Type": "application/json",
@@ -81,7 +81,7 @@ export function runtime(defaults: RequestOpts) {
     form({ body, headers, ...req }: JsonRequestOpts) {
       return {
         ...req,
-        body: qs.form(body),
+        ...(body && { body: qs.form(body) }),
         headers: {
           ...headers,
           "Content-Type": "application/x-www-form-urlencoded",
@@ -90,6 +90,7 @@ export function runtime(defaults: RequestOpts) {
     },
 
     multipart({ body, ...req }: MultipartRequestOpts) {
+      if (!body) return req;
       const data = new FormData();
       Object.entries(body).forEach(([name, value]) => {
         data.append(name, value);


### PR DESCRIPTION
Make the requestBody an optional method parameter when the `required` parameter isn't defined or has a `false` value.

More info on the requestBody property: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#requestBodyObject