### PR TITLE
test: enable all E2E tests

### DIFF
--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -86,7 +86,7 @@ describe("optimistic", () => {
   });
 });
 
-describe.only("--optimistic", () => {
+describe("--optimistic", () => {
   it("should get pets by id", async () => {
     const pet = await optimisticApi.getPetById(1);
     expect(pet).toMatchObject({ id: 1, name: "doggie" });


### PR DESCRIPTION
Enable all E2E tests, not only the `--optimistic` tests.