### PR TITLE
fix(generate): remove spaces from title

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -228,7 +228,7 @@ export default function generateApi(spec: OpenAPIV3.Document, opts?: Opts) {
     if (!ref) {
       const schema = resolve<OpenAPIV3.SchemaObject>(obj);
       const name = getUniqueAlias(
-        _.upperFirst(schema.title || getRefBasename($ref))
+        _.upperFirst(schema.title?.split(' ').join('') || getRefBasename($ref))
       );
 
       ref = refs[$ref] = ts.createTypeReferenceNode(name, undefined);


### PR DESCRIPTION
Addresses: https://github.com/cellular/oazapfts/issues/40

Hi there! Opened a PR to address this. Definitely could've done some regex replacement, but I referenced this stack overflow on speed and decided to go with plain ol' String/Array methods. https://stackoverflow.com/questions/5963182/how-to-remove-spaces-from-a-string-using-javascript

In OpenAPI spec, the `title` attribute is often used for a human-readable description of the schema, so definitely feel like there are many use cases where there'd be spaces in the title 😄. In my use case, I was uploading my OpenAPI spec to readme.io and it was nice to have spaces in the title for readability.

Totally open to feedback, thanks!