### PR TITLE
Extended blob support

### DIFF
--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -1,6 +1,9 @@
-import { ok, handle, okify, optimistic } from "oazapfts/lib/index";
 import * as api from "./api";
 import * as optimisticApi from "./optimisticApi";
+
+import { handle, ok, okify, optimistic } from "oazapfts/lib/index";
+
+import Blob from "cross-blob";
 
 api.defaults.baseUrl = `${process.env.SERVER_URL}/v2`;
 optimisticApi.defaults.baseUrl = `${process.env.SERVER_URL}/v2`;
@@ -116,5 +119,122 @@ describe("--optimistic", () => {
     const pet = await optimisticApi.addPet({ name: "doggie", photoUrls: [] });
     //@ts-expect-error
     expect(pet.name).toBe("doggie");
+  });
+});
+
+describe("Blob", () => {
+  it("should be uploaded", async () => {
+    const emptyPng = new Blob(
+      [
+        Uint8Array.of(
+          0x89,
+          0x50,
+          0x4e,
+          0x47,
+          0xd,
+          0xa,
+          0x1a,
+          0xa,
+          0x0,
+          0x0,
+          0x0,
+          0xd,
+          0x49,
+          0x48,
+          0x44,
+          0x52,
+          0x0,
+          0x0,
+          0x0,
+          0x1,
+          0x0,
+          0x0,
+          0x0,
+          0x1,
+          0x1,
+          0x3,
+          0x0,
+          0x0,
+          0x0,
+          0x25,
+          0xdb,
+          0x56,
+          0xca,
+          0x0,
+          0x0,
+          0x0,
+          0x3,
+          0x50,
+          0x4c,
+          0x54,
+          0x45,
+          0x0,
+          0x0,
+          0x0,
+          0xa7,
+          0x7a,
+          0x3d,
+          0xda,
+          0x0,
+          0x0,
+          0x0,
+          0x1,
+          0x74,
+          0x52,
+          0x4e,
+          0x53,
+          0x0,
+          0x40,
+          0xe6,
+          0xd8,
+          0x66,
+          0x0,
+          0x0,
+          0x0,
+          0xa,
+          0x49,
+          0x44,
+          0x41,
+          0x54,
+          0x8,
+          0xd7,
+          0x63,
+          0x60,
+          0x0,
+          0x0,
+          0x0,
+          0x2,
+          0x0,
+          0x1,
+          0xe2,
+          0x21,
+          0xbc,
+          0x33,
+          0x0,
+          0x0,
+          0x0,
+          0x0,
+          0x49,
+          0x45,
+          0x4e,
+          0x44,
+          0xae,
+          0x42,
+          0x60,
+          0x82
+        ),
+      ],
+      {
+        type: "image/png",
+      }
+    );
+
+    const up = await api.uploadPng(emptyPng);
+
+    expect(up).toMatchObject({
+      code: 200,
+      type: "OK",
+      message: "OK",
+    });
   });
 });

--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -1,9 +1,7 @@
+import Blob from "cross-blob";
+import { handle, ok, okify, optimistic } from "oazapfts/lib/index";
 import * as api from "./api";
 import * as optimisticApi from "./optimisticApi";
-
-import { handle, ok, okify, optimistic } from "oazapfts/lib/index";
-
-import Blob from "cross-blob";
 
 api.defaults.baseUrl = `${process.env.SERVER_URL}/v2`;
 optimisticApi.defaults.baseUrl = `${process.env.SERVER_URL}/v2`;

--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -231,7 +231,7 @@ describe("Blob", () => {
 
     const up = await api.uploadPng(emptyPng);
 
-    expect(up).toMatchObject({
+    expect(up.data).toMatchObject({
       code: 200,
       type: "OK",
       message: "OK",

--- a/demo/api.ts
+++ b/demo/api.ts
@@ -492,3 +492,16 @@ export function getIssue31ByFoo(
     }
   );
 }
+/**
+ * uploads an image in png format
+ */
+export function uploadPng(body?: Blob, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ApiResponse;
+  }>("/uploadPng", {
+    ...opts,
+    method: "POST",
+    body,
+  });
+}

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -536,3 +536,18 @@ export function getIssue31ByFoo(
     )
   );
 }
+/**
+ * uploads an image in png format
+ */
+export function uploadPng(body?: Blob, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.ok(
+    oazapfts.fetchJson<{
+      status: 200;
+      data: ApiResponse;
+    }>("/uploadPng", {
+      ...opts,
+      method: "POST",
+      body,
+    })
+  );
+}

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -918,6 +918,46 @@
           }
         }
       }
+    },
+    "/uploadPng": {
+      "post": {
+        "summary": "uploads an image in png format",
+        "operationId": "uploadPng",
+        "parameters": [],
+        "requestBody": {
+          "description": "The file content.",
+          "content": {
+            "image/png": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                },
+                "example": {
+                  "code": 200,
+                  "type": "OK",
+                  "message": "OK"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
     }
   },
   "components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/lodash": "^4.14.161",
         "@types/minimist": "^1.2.0",
         "@types/node": "^17.0.22",
+        "cross-blob": "^2.0.0",
         "form-data": "^4.0.0",
         "husky": "^7.0.0",
         "jest": "^27.0.5",
@@ -1465,6 +1466,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/blob-polyfill": {
+      "version": "5.0.20210201",
+      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-5.0.20210201.tgz",
+      "integrity": "sha512-SrH6IG6aXL9pCgSysBCiDpGcAJ1j6/c1qCwR3sTEQJhb+MTk6FITNA6eW6WNYQDNZVi4Z9GjxH5v2MMTv59CrQ==",
+      "dev": true
+    },
     "node_modules/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -1972,6 +1979,19 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-blob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cross-blob/-/cross-blob-2.0.1.tgz",
+      "integrity": "sha512-ARuKPPo3I6DSqizal4UCyMCiGPQdMpMJS3Owx6Lleuh26vSt2UnfWRwbMLCYqbJUrcol+KzGVSLR91ezSHP80A==",
+      "dev": true,
+      "dependencies": {
+        "blob-polyfill": "^5.0.20210201",
+        "fetch-blob": "^2.1.2"
+      },
+      "engines": {
+        "node": "^10.17.0 || >=12.3.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2223,34 +2243,6 @@
         "esbuild-windows-arm64": "0.14.2"
       }
     },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.2.tgz",
-      "integrity": "sha512-hEixaKMN3XXCkoe+0WcexO4CcBVU5DCSUT+7P8JZiWZCbAjSkc9b6Yz2X5DSfQmRCtI/cQRU6TfMYrMQ5NBfdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.2.tgz",
-      "integrity": "sha512-Uq8t0cbJQkxkQdbUfOl2wZqZ/AtLZjvJulR1HHnc96UgyzG9YlCLSDMiqjM+NANEy7/zzvwKJsy3iNC9wwqLJA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
     "node_modules/esbuild-darwin-arm64": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.2.tgz",
@@ -2262,202 +2254,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.2.tgz",
-      "integrity": "sha512-aP6FE/ZsChZpUV6F3HE3x1Pz0paoYXycJ7oLt06g0G9dhJKknPawXCqQg/WMyD+ldCEZfo7F1kavenPdIT/SGQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.2.tgz",
-      "integrity": "sha512-LSm98WTb1QIhyS83+Po0KTpZNdd2XpVpI9ua5rLWqKWbKeNRFwOsjeiuwBaRNc+O32s9oC2ZMefETxHBV6VNkQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.2.tgz",
-      "integrity": "sha512-8VxnNEyeUbiGflTKcuVc5JEPTqXfsx2O6ABwUbfS1Hp26lYPRPC7pKQK5Dxa0MBejGc50jy7YZae3EGQUQ8EkQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.2.tgz",
-      "integrity": "sha512-4bzMS2dNxOJoFIiHId4w+tqQzdnsch71JJV1qZnbnErSFWcR9lRgpSqWnTTFtv6XM+MvltRzSXC5wQ7AEBY6Hg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.2.tgz",
-      "integrity": "sha512-PaylahvMHhH8YMfJPMKEqi64qA0Su+d4FNfHKvlKes/2dUe4QxgbwXT9oLVgy8iJdcFMrO7By4R8fS8S0p8aVQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.2.tgz",
-      "integrity": "sha512-RlIVp0RwJrdtasDF1vTFueLYZ8WuFzxoQ1OoRFZOTyJHCGCNgh7xJIC34gd7B7+RT0CzLBB4LcM5n0LS+hIoww==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.2.tgz",
-      "integrity": "sha512-Fdwrq2roFnO5oetIiUQQueZ3+5soCxBSJswg3MvYaXDomj47BN6oAWMZgLrFh1oVrtWrxSDLCJBenYdbm2s+qQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.2.tgz",
-      "integrity": "sha512-vxptskw8JfCDD9QqpRO0XnsM1osuWeRjPaXX1TwdveLogYsbdFtcuiuK/4FxGiNMUr1ojtnCS2rMPbY8puc5NA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.2.tgz",
-      "integrity": "sha512-I8+LzYK5iSNpspS9eCV9sW67Rj8FgMHimGri4mKiGAmN0pNfx+hFX146rYtzGtewuxKtTsPywWteHx+hPRLDsw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.2.tgz",
-      "integrity": "sha512-120HgMe9elidWUvM2E6mMf0csrGwx8sYDqUIJugyMy1oHm+/nT08bTAVXuwYG/rkMIqsEO9AlMxuYnwR6En/3Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.2.tgz",
-      "integrity": "sha512-Q3xcf9Uyfra9UuCFxoLixVvdigo0daZaKJ97TL2KNA4bxRUPK18wwGUk3AxvgDQZpRmg82w9PnkaNYo7a+24ow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.2.tgz",
-      "integrity": "sha512-TW7O49tPsrq+N1sW8mb3m24j/iDGa4xzAZH4wHWwoIzgtZAYPKC0hpIhufRRG/LA30bdMChO9pjJZ5mtcybtBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.2.tgz",
-      "integrity": "sha512-Rym6ViMNmi1E2QuQMWy0AFAfdY0wGwZD73BnzlsQBX5hZBuy/L+Speh7ucUZ16gwsrMM9v86icZUDrSN/lNBKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.2.tgz",
-      "integrity": "sha512-ZrLbhr0vX5Em/P1faMnHucjVVWPS+m3tktAtz93WkMZLmbRJevhiW1y4CbulBd2z0MEdXZ6emDa1zFHq5O5bSA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "peer": true
     },
@@ -2691,6 +2487,20 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
+      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
+      "dev": true,
+      "engines": {
+        "node": "^10.17.0 || >=12.3.0"
+      },
+      "peerDependenciesMeta": {
+        "domexception": {
+          "optional": true
+        }
       }
     },
     "node_modules/fill-range": {
@@ -7639,6 +7449,12 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "blob-polyfill": {
+      "version": "5.0.20210201",
+      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-5.0.20210201.tgz",
+      "integrity": "sha512-SrH6IG6aXL9pCgSysBCiDpGcAJ1j6/c1qCwR3sTEQJhb+MTk6FITNA6eW6WNYQDNZVi4Z9GjxH5v2MMTv59CrQ==",
+      "dev": true
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -8034,6 +7850,16 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-blob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cross-blob/-/cross-blob-2.0.1.tgz",
+      "integrity": "sha512-ARuKPPo3I6DSqizal4UCyMCiGPQdMpMJS3Owx6Lleuh26vSt2UnfWRwbMLCYqbJUrcol+KzGVSLR91ezSHP80A==",
+      "dev": true,
+      "requires": {
+        "blob-polyfill": "^5.0.20210201",
+        "fetch-blob": "^2.1.2"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8235,138 +8061,10 @@
         "esbuild-windows-arm64": "0.14.2"
       }
     },
-    "esbuild-android-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.2.tgz",
-      "integrity": "sha512-hEixaKMN3XXCkoe+0WcexO4CcBVU5DCSUT+7P8JZiWZCbAjSkc9b6Yz2X5DSfQmRCtI/cQRU6TfMYrMQ5NBfdw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-darwin-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.2.tgz",
-      "integrity": "sha512-Uq8t0cbJQkxkQdbUfOl2wZqZ/AtLZjvJulR1HHnc96UgyzG9YlCLSDMiqjM+NANEy7/zzvwKJsy3iNC9wwqLJA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "esbuild-darwin-arm64": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.2.tgz",
       "integrity": "sha512-619MSa17sr7YCIrUj88KzQu2ESA4jKYtIYfLU/smX6qNgxQt3Y/gzM4s6sgJ4fPQzirvmXgcHv1ZNQAs/Xh48A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.2.tgz",
-      "integrity": "sha512-aP6FE/ZsChZpUV6F3HE3x1Pz0paoYXycJ7oLt06g0G9dhJKknPawXCqQg/WMyD+ldCEZfo7F1kavenPdIT/SGQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.2.tgz",
-      "integrity": "sha512-LSm98WTb1QIhyS83+Po0KTpZNdd2XpVpI9ua5rLWqKWbKeNRFwOsjeiuwBaRNc+O32s9oC2ZMefETxHBV6VNkQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.2.tgz",
-      "integrity": "sha512-8VxnNEyeUbiGflTKcuVc5JEPTqXfsx2O6ABwUbfS1Hp26lYPRPC7pKQK5Dxa0MBejGc50jy7YZae3EGQUQ8EkQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.2.tgz",
-      "integrity": "sha512-4bzMS2dNxOJoFIiHId4w+tqQzdnsch71JJV1qZnbnErSFWcR9lRgpSqWnTTFtv6XM+MvltRzSXC5wQ7AEBY6Hg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.2.tgz",
-      "integrity": "sha512-PaylahvMHhH8YMfJPMKEqi64qA0Su+d4FNfHKvlKes/2dUe4QxgbwXT9oLVgy8iJdcFMrO7By4R8fS8S0p8aVQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.2.tgz",
-      "integrity": "sha512-RlIVp0RwJrdtasDF1vTFueLYZ8WuFzxoQ1OoRFZOTyJHCGCNgh7xJIC34gd7B7+RT0CzLBB4LcM5n0LS+hIoww==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.2.tgz",
-      "integrity": "sha512-Fdwrq2roFnO5oetIiUQQueZ3+5soCxBSJswg3MvYaXDomj47BN6oAWMZgLrFh1oVrtWrxSDLCJBenYdbm2s+qQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.2.tgz",
-      "integrity": "sha512-vxptskw8JfCDD9QqpRO0XnsM1osuWeRjPaXX1TwdveLogYsbdFtcuiuK/4FxGiNMUr1ojtnCS2rMPbY8puc5NA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.2.tgz",
-      "integrity": "sha512-I8+LzYK5iSNpspS9eCV9sW67Rj8FgMHimGri4mKiGAmN0pNfx+hFX146rYtzGtewuxKtTsPywWteHx+hPRLDsw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.2.tgz",
-      "integrity": "sha512-120HgMe9elidWUvM2E6mMf0csrGwx8sYDqUIJugyMy1oHm+/nT08bTAVXuwYG/rkMIqsEO9AlMxuYnwR6En/3Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.2.tgz",
-      "integrity": "sha512-Q3xcf9Uyfra9UuCFxoLixVvdigo0daZaKJ97TL2KNA4bxRUPK18wwGUk3AxvgDQZpRmg82w9PnkaNYo7a+24ow==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.2.tgz",
-      "integrity": "sha512-TW7O49tPsrq+N1sW8mb3m24j/iDGa4xzAZH4wHWwoIzgtZAYPKC0hpIhufRRG/LA30bdMChO9pjJZ5mtcybtBQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.2.tgz",
-      "integrity": "sha512-Rym6ViMNmi1E2QuQMWy0AFAfdY0wGwZD73BnzlsQBX5hZBuy/L+Speh7ucUZ16gwsrMM9v86icZUDrSN/lNBKg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.2.tgz",
-      "integrity": "sha512-ZrLbhr0vX5Em/P1faMnHucjVVWPS+m3tktAtz93WkMZLmbRJevhiW1y4CbulBd2z0MEdXZ6emDa1zFHq5O5bSA==",
       "dev": true,
       "optional": true,
       "peer": true
@@ -8558,6 +8256,12 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fetch-blob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
+      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
+      "dev": true
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prettier": "^2.3.1",
     "ts-jest": "^27.0.3",
     "ts-node": "^10.0.0",
-    "with-server": "^2.0.0"
+    "with-server": "^2.0.0",
+    "cross-blob": "^2.0.0"
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.1",

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -10,7 +10,7 @@ export type RequestOpts = {
 } & Omit<RequestInit, "body" | "headers">;
 
 type FetchRequestOpts = RequestOpts & {
-  body?: string | FormData;
+  body?: string | FormData | Blob;
 };
 
 type JsonRequestOpts = RequestOpts & {


### PR DESCRIPTION
Hi cellular team,

I started implementing Blob support as described in #54. Failing Tests as well as the widened type is implemented now. Currently I am struggeling to make the newly added test pass. 

I understand, [open-api-mocker](https://www.npmjs.com/package/open-api-mocker) is being used to mock an api based on petstore.json. All tests pass except my newly added test, that tests blob support. `open-api-mocker` responds with statuscode 400, although I am sure, the test should pass. Unfortunately documentation for `open-api-mocker` is nearly non-existent. Do you have a hint how to debug `open-api-mocker`'s response. Or do you have a different idea for testing?