### PR TITLE
Replace Travis with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+        check-latest: true
+    - run: npm ci
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - "lts/*"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Generate TypeScript clients to tap into OpenAPI servers.
 
-[![Build Status](https://travis-ci.org/cellular/oazapfts.svg?branch=master)](https://travis-ci.org/cellular/oazapfts)
-
 ## Features
 
 - **AST-based**:


### PR DESCRIPTION
Replaces Travis with Github actions, which integrates more tightly with Github and allows forks of the repository to run builds as well.