### PR TITLE
Convert Jest configuration to TypeScript

### DIFF
--- a/demo/jest.config.ts
+++ b/demo/jest.config.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import { Config } from "@jest/types";
+
+const config: Config.InitialOptions = {
   testEnvironment: "node",
   testMatch: ["**/*.test.ts"],
   moduleFileExtensions: ["js", "ts"],
@@ -10,3 +12,5 @@ module.exports = {
     "\\.ts$": "ts-jest",
   },
 };
+
+export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import { Config } from "@jest/types";
+
+const config: Config.InitialOptions = {
   testEnvironment: "node",
   rootDir: "src",
   restoreMocks: true,
@@ -6,3 +8,5 @@ module.exports = {
     "\\.ts$": "ts-jest",
   },
 };
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "oazapfts": "lib/codegen/cli.js"
       },
       "devDependencies": {
+        "@jest/types": "^26.6.2",
         "@types/jest": "^26.0.12",
         "@types/lodash": "^4.14.161",
         "@types/minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "repository": "cellular/oazapfts",
   "devDependencies": {
+    "@jest/types": "^26.6.2",
     "@types/jest": "^26.0.12",
     "@types/lodash": "^4.14.161",
     "@types/minimist": "^1.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": false
   },
-  "exclude": ["demo", "lib", "src/codegen/ApiStub.ts"]
+  "exclude": ["demo", "lib", "src/codegen/ApiStub.ts", "jest.config.ts"]
 }


### PR DESCRIPTION
Allows the Jest configuration to be written in TypeScript, getting all the benefits of it there as well.