### PR TITLE
Do not convert bracket-style deepObject parameters for newer OpenAPI

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -179,7 +179,9 @@ export function supportDeepObjects(params: OpenAPIV3.ParameterObject[]) {
 export default class ApiGenerator {
   constructor(
     public readonly spec: OpenAPIV3.Document,
-    public readonly opts: Opts = {}
+    public readonly opts: Opts = {},
+    /** Indicates if the document was converted from an older version of the OpenAPI specification. */
+    public readonly isConverted = false
   ) {}
 
   aliases: ts.TypeAliasDeclaration[] = [];
@@ -618,10 +620,15 @@ export default class ApiGenerator {
         }
 
         // merge item and op parameters
-        const parameters = supportDeepObjects([
+        const resolvedParameters = [
           ...this.resolveArray(item.parameters),
           ...this.resolveArray(op.parameters),
-        ]);
+        ];
+
+        // expand older OpenAPI parameters into deepObject style where needed
+        const parameters = this.isConverted
+          ? supportDeepObjects(resolvedParameters)
+          : resolvedParameters;
 
         // split into required/optional
         const [required, optional] = _.partition(parameters, "required");

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -13,8 +13,12 @@ export type Opts = {
   optimistic?: boolean;
 };
 
-export function generateAst(spec: OpenAPIV3.Document, opts: Opts) {
-  return new ApiGenerator(spec, opts).generateApi();
+export function generateAst(
+  spec: OpenAPIV3.Document,
+  opts: Opts,
+  isConverted: boolean
+) {
+  return new ApiGenerator(spec, opts, isConverted).generateApi();
 }
 
 export function printAst(ast: ts.SourceFile) {
@@ -31,7 +35,7 @@ export async function generateSource(spec: string, opts: Opts) {
     const result = await converter.convertObj(doc, {});
     v3Doc = result.openapi as OpenAPIV3.Document;
   }
-  const ast = generateAst(v3Doc, opts);
+  const ast = generateAst(v3Doc, opts, !isOpenApiV3);
   const { title, version } = v3Doc.info;
   const preamble = ["$&", title, version].filter(Boolean).join("\n * ");
   const src = printAst(ast);


### PR DESCRIPTION
This prevents newer (v3) OpenAPI specs from being parsed with the legacy behavior for parameters using square brackets to represent a 'deepObject'. In OpenAPI v3 one can simply provide `style: deepObject` to represent these types, and provide a `type: object` with the correct fields.

For more information about these differences, see this [Stack Overflow post](https://stackoverflow.com/a/48498055/1056885).

The main motivation we have to make this change is to make it possible to pass in a schema that has both `foo` and `foo[field]`. If we were to keep the legacy behavior this would mean that we would get two parameters from `supportDeepObjects()` with the same name, which produces incorrect code as we get a type with the same field appearing twice.

For example, the following schema will produce incorrect code without this change in this PR:
```yaml
openapi: 3.0.0
info:
  title: Sample API
  version: 0.1.0
paths:
  /users:
    get:
      summary: Returns a list of users.
      parameters:
        - in: query
          name: page
          schema:
            type: string
            nullable: true
        - in: query
          name: page[size]
          schema:
            type: integer
        - in: query
          name: page[order]
          schema:
            type: string
            enum: [asc, desc]
      responses:
        "200": # status code
          description: A JSON array of user names
          content:
            application/json:
              schema:
                type: array
                items:
                  type: string
```
## Generated code before this PR
```ts
export function getUsers({ page, page }: {
  page?: string | null;
  // This is not valid, a duplicate declaration is not allowed.
  page?: {
      size?: number;
      order?: "asc" | "desc";
  };
} = {}, opts?: Oazapfts.RequestOpts) {
  ...
}
```

## Generated code after this PR
```ts
export function getUsers({ page, pageSize, pageOrder }: {
  page?: string | null;
  pageSize?: number;
  pageOrder?: "asc" | "desc";
} = {}, opts?: Oazapfts.RequestOpts) {
  ...
}
```