### PR TITLE
Allow application/hal+json response types

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -18,9 +18,12 @@ export const verbs = [
   "TRACE",
 ];
 
-export const contentTypes = {
+type ContentType = "json" | "form" | "multipart";
+
+export const contentTypes: Record<string, ContentType> = {
   "*/*": "json",
   "application/json": "json",
+  "application/hal+json": "json",
   "application/x-www-form-urlencoded": "form",
   "multipart/form-data": "multipart",
 };
@@ -503,14 +506,15 @@ export default class ApiGenerator {
       return "text";
     }
 
+    const isJson = resolvedResponses.some((response) => {
+      const responseMimeTypes = Object.keys(response.content ?? {});
+      return responseMimeTypes.some(
+        (mimeType) => contentTypes[mimeType] === "json"
+      );
+    });
+
     // if there’s `application/json` or `*/*`, assume `json`
-    if (
-      resolvedResponses.some(
-        (res) =>
-          !!_.get(res, ["content", "application/json"]) ||
-          !!_.get(res, ["content", "*/*"])
-      )
-    ) {
+    if (isJson) {
       return "json";
     }
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -49,9 +49,16 @@ export function runtime(defaults: RequestOpts) {
         Accept: "application/json",
       },
     });
-    if (contentType && contentType.includes("application/json")) {
-      return { status, data: data && JSON.parse(data) } as T;
+
+    const jsonTypes = ["application/json", "application/hal+json"];
+    const isJson = contentType
+      ? jsonTypes.some((mimeType) => contentType.includes(mimeType))
+      : false;
+
+    if (isJson) {
+      return { status, data: data ? JSON.parse(data) : null } as T;
     }
+
     return { status, data } as T;
   }
 


### PR DESCRIPTION
This allows JSON Hypertext Application Language (HAL) responses with the content type `application/hal+json`. Also cleans up some code so that the content types are no longer duplicated in the code generation.