### PR TITLE
Allow application/problem+json response types

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -24,6 +24,7 @@ export const contentTypes: Record<string, ContentType> = {
   '*/*': 'json',
   'application/json': 'json',
   'application/hal+json': 'json',
+  'application/problem+json' : 'json',
   'application/x-www-form-urlencoded': 'form',
   'multipart/form-data': 'multipart',
 };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -50,7 +50,7 @@ export function runtime(defaults: RequestOpts) {
       },
     });
 
-    const jsonTypes = ["application/json", "application/hal+json"];
+    const jsonTypes = ["application/json", "application/hal+json", "application/problem+json"];
     const isJson = contentType
       ? jsonTypes.some((mimeType) => contentType.includes(mimeType))
       : false;


### PR DESCRIPTION
From experience, some well defined apis define their error types in open api specs, and those may be of the type `application/problem+json`:  https://datatracker.ietf.org/doc/html/rfc7807.

This PR adds support for this content type just as it has for `application/hal+json`