### PR TITLE
Add unionUndefined options for exactOptionalPropertyTypes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "parser": "typescript"
+}


### PR DESCRIPTION
In environments where `exactOptionalPropertyTypes` introduced in typescript 4.4 is enabled, there will be many situations where you want to union `undefined` for parameters with a `questionToken`.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#exact-optional-property-types---exactoptionalpropertytypes
