### PR TITLE
Allow application/geo+json response types

### DIFF
--- a/demo/geojson.json
+++ b/demo/geojson.json
@@ -1,0 +1,83 @@
+{
+  "info": {
+    "title": "example with GeoJSON download",
+    "version": "0.0.1",
+    "description": "The example is taken from RFC 7946, 1.5: Example"
+  },
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/geojson": {
+      "get": {
+        "operationId": "GetGeoJSON",
+        "description": "Get GeoJSON JSON data",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FeatureCollection": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["FeatureCollection"]
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Feature"
+            }
+          }
+        }
+      },
+      "Feature": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["Feature"]
+          },
+          "geometry": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["Point"]
+              },
+              "coordinates": {
+                "type": "array",
+                "example": "[102.0, 0.5]"
+              }
+            }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "prop0": {
+                "type": "string",
+                "example": "value0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -53,7 +53,7 @@ describe("generate with application/geo+json", () => {
     const artefact = printAst(new ApiGenerator(spec).generateApi());
     const oneLine = artefact.replace(/\s+/g, " ");
     expect(oneLine).toContain(
-      "return oazapfts.fetchJson<{ status: 200; data: FeatureCollection; }>(`/geojson`, { ...opts });"
+      'return oazapfts.fetchJson<{ status: 200; data: FeatureCollection; }>("/geojson", { ...opts });'
     );
   });
 });

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -40,6 +40,24 @@ describe("generate", () => {
   });
 });
 
+describe("generate with application/geo+json", () => {
+  let spec: OpenAPIV3.Document;
+
+  beforeAll(async () => {
+    spec = (await SwaggerParser.bundle(
+      __dirname + "/../../demo/geojson.json"
+    )) as any;
+  });
+
+  it("should generate an api", async () => {
+    const artefact = printAst(new ApiGenerator(spec).generateApi());
+    const oneLine = artefact.replace(/\s+/g, " ");
+    expect(oneLine).toContain(
+      "return oazapfts.fetchJson<{ status: 200; data: FeatureCollection; }>(`/geojson`, { ...opts });"
+    );
+  });
+});
+
 describe("generate with blob download", () => {
   let spec: OpenAPIV3.Document;
 

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -25,6 +25,7 @@ export const contentTypes: Record<string, ContentType> = {
   'application/json': 'json',
   'application/hal+json': 'json',
   'application/problem+json' : 'json',
+  'application/geo+json' : 'json',
   'application/x-www-form-urlencoded': 'form',
   'multipart/form-data': 'multipart',
 };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -50,7 +50,7 @@ export function runtime(defaults: RequestOpts) {
       },
     });
 
-    const jsonTypes = ["application/json", "application/hal+json", "application/problem+json"];
+    const jsonTypes = ["application/json", "application/hal+json", "application/problem+json", "application/geo+json"];
     const isJson = contentType
       ? jsonTypes.some((mimeType) => contentType.includes(mimeType))
       : false;


### PR DESCRIPTION
Some well defined apis define their geojson types in OpenAPI specs, and those may be of the type `application/geo+json`: https://datatracker.ietf.org/doc/html/rfc7946. 

This include some of the API specs I am using, which when using this type today to render TS oazapfts unfortunately ends up using the Blob data type.

This PR adds support for this content type just as it has for `application/hal+json` and `application/problem+json`.

In short, this PR is based on the recently merged https://github.com/cellular/oazapfts/pull/197 one.
