### PR TITLE
Add Dependabot config for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 999
+    rebase-strategy: disabled
     schedule:
-      interval: "weekly"
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 999
+    rebase-strategy: disabled
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds a Dependabot config to keep the Github Actions up to date. Also changes PR limit so Dependabot can open up more than 5 PRs at a time.