### PR TITLE
serialize object query parameters as exploded form by default

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -56,6 +56,7 @@ export type User = {
 };
 export type Schema = string;
 export type Schema2 = number;
+export type Option = ("one" | "two" | "three")[];
 /**
  * Update an existing pet
  */
@@ -372,7 +373,7 @@ export function loginUser(
       }
   >(
     `/user/login${QS.query(
-      QS.form({
+      QS.explode({
         username,
         password,
       })
@@ -451,7 +452,7 @@ export function customizePet(
 ) {
   return oazapfts.fetchText(
     `/pet/customize${QS.query(
-      QS.form({
+      QS.explode({
         "fur.color": furColor,
         color,
       })
@@ -481,10 +482,73 @@ export function getIssue31ByFoo(
 ) {
   return oazapfts.fetchText(
     `/issue31/${encodeURIComponent(foo)}${QS.query(
-      QS.form({
+      QS.explode({
         bar,
         baz,
         boo,
+      })
+    )}`,
+    {
+      ...opts,
+    }
+  );
+}
+export function getObjectParameters(
+  {
+    defaultArray,
+    explodedFormArray,
+    commaArray,
+    defaultSpaceDelimited,
+    explodedSpaceDelimited,
+    spaceDelimited,
+    defaultPipeDelimited,
+    explodedPipeDelimited,
+    pipeDelimited,
+    defaultObject,
+    explodedFormObject,
+    commaObject,
+    deepObject,
+  }: {
+    defaultArray?: Option;
+    explodedFormArray?: Option;
+    commaArray?: Option;
+    defaultSpaceDelimited?: Option;
+    explodedSpaceDelimited?: Option;
+    spaceDelimited?: Option;
+    defaultPipeDelimited?: Option;
+    explodedPipeDelimited?: Option;
+    pipeDelimited?: Option;
+    defaultObject?: Tag;
+    explodedFormObject?: Tag;
+    commaObject?: Tag;
+    deepObject?: Tag;
+  } = {},
+  opts?: Oazapfts.RequestOpts
+) {
+  return oazapfts.fetchText(
+    `/object-parameters${QS.query(
+      QS.explode({
+        defaultArray,
+        explodedFormArray,
+        defaultSpaceDelimited,
+        explodedSpaceDelimited,
+        defaultPipeDelimited,
+        explodedPipeDelimited,
+        defaultObject,
+        explodedFormObject,
+      }),
+      QS.form({
+        commaArray,
+        commaObject,
+      }),
+      QS.space({
+        spaceDelimited,
+      }),
+      QS.pipe({
+        pipeDelimited,
+      }),
+      QS.deep({
+        deepObject,
       })
     )}`,
     {

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -56,6 +56,7 @@ export type User = {
 };
 export type Schema = string;
 export type Schema2 = number;
+export type Option = ("one" | "two" | "three")[];
 /**
  * Update an existing pet
  */
@@ -403,7 +404,7 @@ export function loginUser(
         }
     >(
       `/user/login${QS.query(
-        QS.form({
+        QS.explode({
           username,
           password,
         })
@@ -492,7 +493,7 @@ export function customizePet(
   return oazapfts.ok(
     oazapfts.fetchText(
       `/pet/customize${QS.query(
-        QS.form({
+        QS.explode({
           "fur.color": furColor,
           color,
         })
@@ -524,10 +525,75 @@ export function getIssue31ByFoo(
   return oazapfts.ok(
     oazapfts.fetchText(
       `/issue31/${encodeURIComponent(foo)}${QS.query(
-        QS.form({
+        QS.explode({
           bar,
           baz,
           boo,
+        })
+      )}`,
+      {
+        ...opts,
+      }
+    )
+  );
+}
+export function getObjectParameters(
+  {
+    defaultArray,
+    explodedFormArray,
+    commaArray,
+    defaultSpaceDelimited,
+    explodedSpaceDelimited,
+    spaceDelimited,
+    defaultPipeDelimited,
+    explodedPipeDelimited,
+    pipeDelimited,
+    defaultObject,
+    explodedFormObject,
+    commaObject,
+    deepObject,
+  }: {
+    defaultArray?: Option;
+    explodedFormArray?: Option;
+    commaArray?: Option;
+    defaultSpaceDelimited?: Option;
+    explodedSpaceDelimited?: Option;
+    spaceDelimited?: Option;
+    defaultPipeDelimited?: Option;
+    explodedPipeDelimited?: Option;
+    pipeDelimited?: Option;
+    defaultObject?: Tag;
+    explodedFormObject?: Tag;
+    commaObject?: Tag;
+    deepObject?: Tag;
+  } = {},
+  opts?: Oazapfts.RequestOpts
+) {
+  return oazapfts.ok(
+    oazapfts.fetchText(
+      `/object-parameters${QS.query(
+        QS.explode({
+          defaultArray,
+          explodedFormArray,
+          defaultSpaceDelimited,
+          explodedSpaceDelimited,
+          defaultPipeDelimited,
+          explodedPipeDelimited,
+          defaultObject,
+          explodedFormObject,
+        }),
+        QS.form({
+          commaArray,
+          commaObject,
+        }),
+        QS.space({
+          spaceDelimited,
+        }),
+        QS.pipe({
+          pipeDelimited,
+        }),
+        QS.deep({
+          deepObject,
         })
       )}`,
       {

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -919,6 +919,124 @@
         }
       }
     },
+    "/object-parameters": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "defaultArray",
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "explodedFormArray",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "commaArray",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "defaultSpaceDelimited",
+            "style": "spaceDelimited",
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "explodedSpaceDelimited",
+            "style": "spaceDelimited",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "spaceDelimited",
+            "style": "spaceDelimited",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "defaultPipeDelimited",
+            "style": "pipeDelimited",
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "explodedPipeDelimited",
+            "style": "pipeDelimited",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pipeDelimited",
+            "style": "pipeDelimited",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/Option"
+            }
+          },
+          {
+            "in": "query",
+            "name": "defaultObject",
+            "schema": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          {
+            "in": "query",
+            "name": "explodedFormObject",
+            "explode": true,
+            "schema": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          {
+            "in": "query",
+            "name": "commaObject",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          {
+            "in": "query",
+            "name": "deepObject",
+            "style": "deepObject",
+            "schema": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
     "/uploadPng": {
       "post": {
         "summary": "uploads an image in png format",
@@ -1117,6 +1235,14 @@
           "message": {
             "type": "string"
           }
+        }
+      },
+      "Option": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "default": ["one"],
+          "enum": ["one", "two", "three"]
         }
       }
     },

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -33,11 +33,15 @@ export const contentTypes: Record<string, ContentType> = {
 /**
  * Get the name of a formatter function for a given parameter.
  */
-export function getFormatter({ style, explode }: OpenAPIV3.ParameterObject) {
+export function getFormatter({
+  style = "form",
+  explode = true,
+}: OpenAPIV3.ParameterObject) {
+  if (explode && style === "deepObject") return "deep";
+  if (explode) return "explode";
   if (style === "spaceDelimited") return "space";
   if (style === "pipeDelimited") return "pipe";
-  if (style === "deepObject") return "deep";
-  return explode ? "explode" : "form";
+  return "form";
 }
 
 export function getOperationIdentifier(id?: string) {

--- a/src/runtime/query.ts
+++ b/src/runtime/query.ts
@@ -4,7 +4,7 @@ import { encode, delimited, encodeReserved } from "./util";
  * Join params using an ampersand and prepends a questionmark if not empty.
  */
 export function query(...params: string[]) {
-  const s = params.join("&");
+  const s = params.filter(Boolean).join("&");
   return s && `?${s}`;
 }
 


### PR DESCRIPTION
As described in https://github.com/cellular/oazapfts/issues/269, we were not handling object parameters according to swagger specification.

BREAKING CHANGE:
When `style` and/or `explode` are not explicitly set on a path parameter in your swagger.json
Then in the past oazapfts had send an array as `?key=a,b`
From now on the same data is sent as `?key=a&key=b`
Also space and pipe delimited serialization now requires explicit disabling of explode to be effective

**Migration:**
When your backend implements the OpenAPI Specification correctly, you do not need to do anything.

If not, or you're unsure, in your swagger.json:
- Set `"explode": false` on all array and object path parameters that had no explicit explode setting before
- Except for object parameters with `"style": "deepObject"`. These have been handled correctly and you should not change them.

See https://swagger.io/docs/specification/serialization/#query for details


---

Props to @jannik-hh who discovered the issue