### PR TITLE
feat: add support for 'const' keyword

### DIFF
--- a/demo/const.json
+++ b/demo/const.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Swagger const example",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://testUrl.test"
+    }
+  ],
+  "paths": {
+    "/shape/{circle_id}": {
+      "get": {
+        "tags": ["circle"],
+        "summary": "Find circle by ID",
+        "description": "Returns a single circle",
+        "operationId": "getCircleById",
+        "parameters": [
+          {
+            "name": "circle_id",
+            "in": "path",
+            "description": "ID of circle to return",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Circle"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Shape": {
+        "const": "circle"
+      },
+      "Circle": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "shape": {
+            "$ref": "#/components/schemas/Shape"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -55,6 +55,15 @@ describe("generate", () => {
 
     expect(oneLine).toContain(circleTypeDefinition);
   });
+
+  it("should handle enums", async () => {
+    const api = printAst(new ApiGenerator(spec.petstore).generateApi());
+    const oneLine = api.replace(/\s+/g, " ");
+
+    const enumTypeDefinition = `export type Option = ("one" | "two" | "three")[];`;
+
+    expect(oneLine).toContain(enumTypeDefinition);
+  });
 });
 
 describe("generate with application/geo+json", () => {
@@ -90,5 +99,22 @@ describe("generate with blob download", () => {
     expect(oneLine).toContain(
       "return oazapfts.fetchBlob<{ status: 200; data: Blob; }>(`/file/${encodeURIComponent(fileId)}/download`, { ...opts });"
     );
+  });
+});
+
+describe("generate with const", () => {
+  let spec: OpenAPIV3.Document;
+
+  beforeAll(async () => {
+    spec = (await SwaggerParser.bundle(
+      __dirname + "/../../demo/const.json"
+    )) as any;
+  });
+
+  it("should generate an api with literal type set to const value", async () => {
+    const artefact = printAst(new ApiGenerator(spec).generateApi());
+    const oneLine = artefact.replace(/\s+/g, " ");
+    const constTypeDefinition = `export type Shape = "circle";`;
+    expect(oneLine).toContain(constTypeDefinition);
   });
 });

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -5,7 +5,6 @@ import { OpenAPIV3 } from "openapi-types";
 import * as cg from "./tscodegen";
 import generateServers, { defaultBaseUrl } from "./generateServers";
 import { Opts } from ".";
-import { threadId } from "worker_threads";
 
 export const verbs = [
   "GET",
@@ -28,6 +27,11 @@ export const contentTypes: Record<string, ContentType> = {
   "application/geo+json": "json",
   "application/x-www-form-urlencoded": "form",
   "multipart/form-data": "multipart",
+};
+
+// augment SchemaObject type to allow slowly adopting new OAS3.1+ features
+type SchemaObject = OpenAPIV3.SchemaObject & {
+  const?: any;
 };
 
 /**
@@ -262,7 +266,7 @@ export default class ApiGenerator {
     const { $ref } = obj;
     let ref = this.refs[$ref];
     if (!ref) {
-      const schema = this.resolve<OpenAPIV3.SchemaObject>(obj);
+      const schema = this.resolve<SchemaObject>(obj);
       const name = this.getUniqueAlias(
         _.upperFirst(_.camelCase(schema.title || this.getRefBasename($ref)))
       );
@@ -282,7 +286,7 @@ export default class ApiGenerator {
   }
 
   getUnionType(
-    variants: (OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject)[],
+    variants: (OpenAPIV3.ReferenceObject | SchemaObject)[],
     discriminator?: OpenAPIV3.DiscriminatorObject
   ): ts.TypeNode {
     if (discriminator) {
@@ -354,7 +358,7 @@ export default class ApiGenerator {
    * optionally adds a union with null.
    */
   getTypeFromSchema(
-    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+    schema?: SchemaObject | OpenAPIV3.ReferenceObject
   ): ts.TypeNode {
     const type = this.getBaseTypeFromSchema(schema);
     return isNullable(schema)
@@ -367,7 +371,7 @@ export default class ApiGenerator {
    * schema and returns the appropriate type.
    */
   getBaseTypeFromSchema(
-    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+    schema?: SchemaObject | OpenAPIV3.ReferenceObject
   ): ts.TypeNode {
     if (!schema) return cg.keywordType.any;
     if (isReference(schema)) {
@@ -415,25 +419,13 @@ export default class ApiGenerator {
       );
     }
     if (schema.enum) {
-      // enum -> union of literal types
-      const types = schema.enum.map((s) => {
-        if (s === null) return cg.keywordType.null;
-        if (typeof s === "boolean")
-          return s
-            ? factory.createLiteralTypeNode(
-                ts.factory.createToken(ts.SyntaxKind.TrueKeyword)
-              )
-            : factory.createLiteralTypeNode(
-                ts.factory.createToken(ts.SyntaxKind.FalseKeyword)
-              );
-        if (typeof s === "number")
-          return factory.createLiteralTypeNode(factory.createNumericLiteral(s));
-        return factory.createLiteralTypeNode(factory.createStringLiteral(s));
-      });
-      return types.length > 1 ? factory.createUnionTypeNode(types) : types[0];
+      return this.getTypeFromEnum(schema.enum);
     }
     if (schema.format == "binary") {
       return factory.createTypeReferenceNode("Blob", []);
+    }
+    if (schema.const) {
+      return this.getTypeFromEnum([schema.const]);
     }
     if (schema.type) {
       // string, boolean, null, number
@@ -445,17 +437,35 @@ export default class ApiGenerator {
   }
 
   /**
+   * Creates literal type (or union) from an array of values
+   */
+  getTypeFromEnum(values: any[]) {
+    const types = values.map((s) => {
+      if (s === null) return cg.keywordType.null;
+      if (typeof s === "boolean")
+        return s
+          ? factory.createLiteralTypeNode(
+              ts.factory.createToken(ts.SyntaxKind.TrueKeyword)
+            )
+          : factory.createLiteralTypeNode(
+              ts.factory.createToken(ts.SyntaxKind.FalseKeyword)
+            );
+      if (typeof s === "number")
+        return factory.createLiteralTypeNode(factory.createNumericLiteral(s));
+      return factory.createLiteralTypeNode(factory.createStringLiteral(s));
+    });
+    return types.length > 1 ? factory.createUnionTypeNode(types) : types[0];
+  }
+
+  /**
    * Recursively creates a type literal with the given props.
    */
   getTypeFromProperties(
     props: {
-      [prop: string]: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject;
+      [prop: string]: SchemaObject | OpenAPIV3.ReferenceObject;
     },
     required?: string[],
-    additionalProperties?:
-      | boolean
-      | OpenAPIV3.SchemaObject
-      | OpenAPIV3.ReferenceObject
+    additionalProperties?: boolean | SchemaObject | OpenAPIV3.ReferenceObject
   ) {
     const members: ts.TypeElement[] = Object.keys(props).map((name) => {
       const schema = props[name];

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -5,6 +5,7 @@ import { OpenAPIV3 } from "openapi-types";
 import * as cg from "./tscodegen";
 import generateServers, { defaultBaseUrl } from "./generateServers";
 import { Opts } from ".";
+import { threadId } from "worker_threads";
 
 export const verbs = [
   "GET",

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -32,7 +32,7 @@ export const contentTypes: Record<string, ContentType> = {
 
 // augment SchemaObject type to allow slowly adopting new OAS3.1+ features
 type SchemaObject = OpenAPIV3.SchemaObject & {
-  const?: any;
+  const?: unknown;
 };
 
 /**


### PR DESCRIPTION
Closes #291 

I implemented this by strictly interpreting the spec which states that "const" is just shorthand for an enum with a single value.

I did notice that enum values right now are restricted to primitive types, when technically object literals are valid (though I've never had a use case for them). I started to take a stab at providing support, but it was a little trickier than I thought since an ObjectLiteralExpression does not extend TypeNode, and I couldn't figure out how to reconcile that difference without altering the fundamental return type of many of the library's methods. Regardless, it was sufficiently complex enough to deserve its own PR if there is interest.