### PR TITLE
feat: add JSDoc comments to output

### DIFF
--- a/src/codegen/tscodegen.ts
+++ b/src/codegen/tscodegen.ts
@@ -455,7 +455,10 @@ export function appendNodes<T extends ts.Node>(
   return factory.createNodeArray([...array, ...nodes]);
 }
 
-export function addComment<T extends ts.Node>(node: T, comment?: string) {
+export function addComment<T extends ts.Node>(
+  node: T,
+  comment: string | undefined
+) {
   if (!comment) return node;
   return ts.addSyntheticLeadingComment(
     node,


### PR DESCRIPTION
This is a work-in-progress proof of concept PR for including JSDoc comments in the output.

It currently works with type aliases and their properties, functions and their required parameters, and optional parameter properties.

It still needs tests.