### PR TITLE
fix: remove duplicate parameters

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -673,10 +673,10 @@ export default class ApiGenerator {
         }
 
         // merge item and op parameters
-        const resolvedParameters = [
+        const resolvedParameters = _.uniq([
           ...this.resolveArray(item.parameters),
           ...this.resolveArray(op.parameters),
-        ];
+        ]);
 
         // expand older OpenAPI parameters into deepObject style where needed
         const parameters = this.isConverted


### PR DESCRIPTION
When OpenAPI specs reference parameters more than once in the same hierarchy, like this snippet from Asana's OpenAPI spec, oazapfts produces duplicate parameters. This fixes that by removing duplicate parameters from `resolvedParameters`.

```yaml
  /projects/{project_gid}/project_statuses:
    parameters:
      - $ref: '#/components/parameters/project_path_gid'
      - $ref: '#/components/parameters/pretty'
      - $ref: '#/components/parameters/fields'
    get:
      summary: Get statuses from a project
      description: |-
        *Deprecated: new integrations should prefer the `/status_updates` route.*

        Returns the compact project status update records for all updates on the project.
      tags:
        - Project Statuses
      operationId: getProjectStatusesForProject
      parameters:
        - $ref: '#/components/parameters/project_path_gid'
        - $ref: '#/components/parameters/pretty'
        - $ref: '#/components/parameters/fields'
        - $ref: '#/components/parameters/limit'
        - $ref: '#/components/parameters/offset'
```

Fixes #58