### PR TITLE
Adding an option to generate typescript enum instead of union of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ oazapfts <spec> [filename]
 Options:
 --exclude, -e tag to exclude
 --include, -i tag to include
+--optimistic
+--useEnumType
 ```
 
 Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either json or yml) and `<filename>` is the location of the `.ts` file to be generated. If the filename is omitted, the code is written to stdout.
+
+Use the `useEnumType` option to generate typescript enums instead of union of values.
 
 ## Overriding the defaults
 

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -29,7 +29,7 @@ export type Pet = {
   photoUrls: string[];
   tags?: Tag[];
   status?: Status;
-  animal?: Animal;
+  animal?: true;
   size?: Size;
 };
 export type ApiResponse = {
@@ -574,9 +574,6 @@ export enum Status {
   Available = "Available",
   Pending = "Pending",
   Sold = "Sold",
-}
-export enum Animal {
-  true = "true",
 }
 export enum Size {
   P = 0,

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -28,9 +28,9 @@ export type Pet = {
   name: string;
   photoUrls: string[];
   tags?: Tag[];
-  status?: "available" | "pending" | "sold";
-  animal?: true;
-  size?: "P" | "M" | "G";
+  status?: Status;
+  animal?: Animal;
+  size?: Size;
 };
 export type ApiResponse = {
   code?: number;
@@ -42,7 +42,7 @@ export type Order = {
   petId?: number;
   quantity?: number;
   shipDate?: string;
-  status?: "placed" | "approved" | "delivered";
+  status?: Status2;
   complete?: boolean;
 };
 export type User = {
@@ -569,4 +569,22 @@ export function uploadPng(body?: Blob, opts?: Oazapfts.RequestOpts) {
     method: "POST",
     body,
   });
+}
+export enum Status {
+  Available = "Available",
+  Pending = "Pending",
+  Sold = "Sold",
+}
+export enum Animal {
+  true = "true",
+}
+export enum Size {
+  P = 0,
+  M = 1,
+  G = 2,
+}
+export enum Status2 {
+  Placed = "Placed",
+  Approved = "Approved",
+  Delivered = "Delivered",
 }

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -30,6 +30,7 @@ export type Pet = {
   tags?: Tag[];
   status?: "available" | "pending" | "sold";
   animal?: true;
+  size?: "P" | "M" | "G";
 };
 export type ApiResponse = {
   code?: number;

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1216,6 +1216,11 @@
             "description": "Always true for a pet",
             "enum": [true],
             "type": "boolean"
+          },
+          "size": {
+            "description": "Size scale for pets",
+            "enum": ["P", "M", "G"],
+            "type": "number"
           }
         },
         "xml": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "jest",
     "test:e2e": "npm run generate-demo && with-server 'cd demo && jest'",
     "start": "open-api-mocker -p $PORT -s demo/petstore.json",
-    "generate-demo": "npm run prepare && ./lib/codegen/cli.js ./demo/petstore.json ./demo/api.ts && ./lib/codegen/cli.js --optimistic ./demo/petstore.json ./demo/optimisticApi.ts && prettier -w demo",
+    "generate-demo": "npm run prepare && ./lib/codegen/cli.js ./demo/petstore.json ./demo/api.ts && ./lib/codegen/cli.js --optimistic ./demo/petstore.json ./demo/optimisticApi.ts && ./lib/codegen/cli.js --useEnumType ./demo/petstore.json ./demo/enumApi.ts && prettier -w demo",
     "prepare": "npm run build && chmod +x ./lib/codegen/cli.js && husky install"
   },
   "keywords": [

--- a/src/codegen/cli.ts
+++ b/src/codegen/cli.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 
+import { Opts, generateSource } from "./";
+
 import fs from "fs";
 import minimist from "minimist";
-
-import { generateSource, Opts } from "./";
 
 const argv = minimist(process.argv.slice(2), {
   alias: {
     i: "include",
     e: "exclude",
   },
-  boolean: ["optimistic"],
+  boolean: ["optimistic", "useEnumType"],
 });
 
 async function generate(spec: string, dest: string, opts: Opts) {
@@ -19,7 +19,7 @@ async function generate(spec: string, dest: string, opts: Opts) {
   else console.log(code);
 }
 
-const { include, exclude, optimistic } = argv;
+const { include, exclude, optimistic, useEnumType } = argv;
 const [spec, dest] = argv._;
 if (!spec) {
   console.error(`
@@ -30,6 +30,7 @@ if (!spec) {
     --exclude, -e <tag to exclude>
     --include, -i <tag to include>
     --optimistic
+    --useEnumType
 `);
   process.exit(1);
 }
@@ -38,4 +39,5 @@ generate(spec, dest, {
   include,
   exclude,
   optimistic,
+  useEnumType,
 });

--- a/src/codegen/cli.ts
+++ b/src/codegen/cli.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { Opts, generateSource } from "./";
-
 import fs from "fs";
 import minimist from "minimist";
+
+import { generateSource, Opts } from "./";
 
 const argv = minimist(process.argv.slice(2), {
   alias: {

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -1,8 +1,9 @@
 import generate, { getOperationName } from "./generate";
-import { printAst } from "./index";
-import SwaggerParser from "@apidevtools/swagger-parser";
-import { OpenAPIV3 } from "openapi-types";
+
 import ApiGenerator from "./generate";
+import { OpenAPIV3 } from "openapi-types";
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { printAst } from "./index";
 
 describe("getOperationName", () => {
   it("should use the id", () => {
@@ -56,13 +57,40 @@ describe("generate", () => {
     expect(oneLine).toContain(circleTypeDefinition);
   });
 
-  it("should handle enums", async () => {
+  it("should handle enums as union types", async () => {
     const api = printAst(new ApiGenerator(spec.petstore).generateApi());
     const oneLine = api.replace(/\s+/g, " ");
 
     const enumTypeDefinition = `export type Option = ("one" | "two" | "three")[];`;
 
     expect(oneLine).toContain(enumTypeDefinition);
+  });
+
+  it("should create real enums", async () => {
+    const api = printAst(
+      new ApiGenerator(spec.petstore, { useEnumType: true }).generateApi()
+    );
+    const oneLine = api.replace(/\s+/g, " ");
+
+    // Enum type string
+    const enumDefinition = `export enum Status { Available = "Available", Pending = "Pending", Sold = "Sold" }`;
+
+    expect(oneLine).toContain(enumDefinition);
+
+    // Enum type string
+    const enumBoolDefinition = `export enum Animal { true = "true" }`;
+
+    expect(oneLine).toContain(enumBoolDefinition);
+
+    // Enum type number
+    const enumNumberDefinition = `export enum Size { P = 0, M = 1, G = 2 }`;
+
+    expect(oneLine).toContain(enumNumberDefinition);
+
+    // Enums with different values but same name should result in a different instance name
+    const sameNameDefinition = `export enum Status2 { Placed = "Placed", Approved = "Approved", Delivered = "Delivered" }`;
+
+    expect(oneLine).toContain(sameNameDefinition);
   });
 });
 

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -1,9 +1,7 @@
-import generate, { getOperationName } from "./generate";
-
-import ApiGenerator from "./generate";
-import { OpenAPIV3 } from "openapi-types";
-import SwaggerParser from "@apidevtools/swagger-parser";
+import ApiGenerator, { getOperationName } from "./generate";
 import { printAst } from "./index";
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { OpenAPIV3 } from "openapi-types";
 
 describe("getOperationName", () => {
   it("should use the id", () => {
@@ -76,11 +74,6 @@ describe("generate", () => {
     const enumDefinition = `export enum Status { Available = "Available", Pending = "Pending", Sold = "Sold" }`;
 
     expect(oneLine).toContain(enumDefinition);
-
-    // Enum type string
-    const enumBoolDefinition = `export enum Animal { true = "true" }`;
-
-    expect(oneLine).toContain(enumBoolDefinition);
 
     // Enum type number
     const enumNumberDefinition = `export enum Size { P = 0, M = 1, G = 2 }`;

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1,10 +1,12 @@
-import _ from "lodash";
-import ts, { factory } from "typescript";
-import path from "path";
-import { OpenAPIV3 } from "openapi-types";
 import * as cg from "./tscodegen";
+
+import _, { values } from "lodash";
 import generateServers, { defaultBaseUrl } from "./generateServers";
+import ts, { Statement, factory } from "typescript";
+
+import { OpenAPIV3 } from "openapi-types";
 import { Opts } from ".";
+import path from "path";
 import { threadId } from "worker_threads";
 
 export const verbs = [
@@ -207,6 +209,10 @@ export default class ApiGenerator {
 
   aliases: ts.TypeAliasDeclaration[] = [];
 
+  enumAliases: ts.Statement[] = [];
+  typeEnumAliases: Record<string, number> = {};
+  enumRefs: Record<string, { values: string; type: ts.TypeReferenceNode }> = {};
+
   // Collect the types of all referenced schemas so we can export them later
   refs: Record<string, ts.TypeReferenceNode> = {};
 
@@ -215,6 +221,7 @@ export default class ApiGenerator {
 
   reset() {
     this.aliases = [];
+    this.enumAliases = [];
     this.refs = {};
     this.typeAliases = {};
   }
@@ -254,6 +261,24 @@ export default class ApiGenerator {
     }
     this.typeAliases[name] = 1;
     return name;
+  }
+
+  getEnumUniqueAlias(name: string, values: string) {
+    // If the enum does not exist
+    if (!this.enumRefs[name]) {
+      this.typeEnumAliases[name] = 1;
+      return name;
+
+      // If enum name already exists and have the same values
+    } else if (this.enumRefs[name] && this.enumRefs[name].values == values) {
+      return name;
+
+      // If the already exists but has a different value: eg Status2
+    } else {
+      this.typeEnumAliases[name] += 1;
+      name += this.typeEnumAliases[name];
+      return name;
+    }
   }
 
   getRefBasename(ref: string): string {
@@ -359,9 +384,10 @@ export default class ApiGenerator {
    * optionally adds a union with null.
    */
   getTypeFromSchema(
-    schema?: SchemaObject | OpenAPIV3.ReferenceObject
+    schema?: SchemaObject | OpenAPIV3.ReferenceObject,
+    name?: string
   ): ts.TypeNode {
-    const type = this.getBaseTypeFromSchema(schema);
+    const type = this.getBaseTypeFromSchema(schema, name);
     return isNullable(schema)
       ? factory.createUnionTypeNode([type, cg.keywordType.null])
       : type;
@@ -372,7 +398,8 @@ export default class ApiGenerator {
    * schema and returns the appropriate type.
    */
   getBaseTypeFromSchema(
-    schema?: SchemaObject | OpenAPIV3.ReferenceObject
+    schema?: SchemaObject | OpenAPIV3.ReferenceObject,
+    name?: string
   ): ts.TypeNode {
     if (!schema) return cg.keywordType.any;
     if (isReference(schema)) {
@@ -420,7 +447,9 @@ export default class ApiGenerator {
       );
     }
     if (schema.enum) {
-      return this.getTypeFromEnum(schema.enum);
+      return this.opts.useEnumType && name
+        ? this.getTrueEnum(schema, name)
+        : this.getTypeFromEnum(schema.enum);
     }
     if (schema.format == "binary") {
       return factory.createTypeReferenceNode("Blob", []);
@@ -460,6 +489,60 @@ export default class ApiGenerator {
     return types.length > 1 ? factory.createUnionTypeNode(types) : types[0];
   }
 
+  getEnumValuesString(values: string[]): string {
+    return values.join("_");
+  }
+
+  /*
+    Creates a enum "ref" if not used, reuse existing if values and name matches or creates a new one
+    with a new name adding a number
+  */
+  getTrueEnum(schema: OpenAPIV3.NonArraySchemaObject, propName: string) {
+    const proposedName = schema.title || _.upperFirst(propName);
+    const stringEnumValue = this.getEnumValuesString(
+      schema.enum ? schema.enum : []
+    );
+
+    const name = this.getEnumUniqueAlias(proposedName, stringEnumValue);
+
+    if (this.enumRefs[proposedName] && proposedName === name) {
+      return this.enumRefs[proposedName].type;
+    }
+
+    const values = schema.enum ? schema.enum : [];
+
+    const members = values.map((s, index) => {
+      if (schema.type === "boolean") {
+        s = Boolean(s) ? "true" : "false";
+      } else if (schema.type === "string") {
+        s = _.upperFirst(s);
+      }
+      return factory.createEnumMember(
+        factory.createIdentifier(s),
+        schema.type === "number"
+          ? factory.createNumericLiteral(index)
+          : factory.createStringLiteral(s)
+      );
+    });
+    this.enumAliases.push(
+      factory.createEnumDeclaration(
+        undefined,
+        [cg.modifier.export],
+        name,
+        members
+      )
+    );
+
+    const type = factory.createTypeReferenceNode(name, undefined);
+
+    this.enumRefs[proposedName] = {
+      values: stringEnumValue,
+      type: factory.createTypeReferenceNode(name, undefined),
+    };
+
+    return type;
+  }
+
   /**
    * Recursively creates a type literal with the given props.
    */
@@ -473,7 +556,7 @@ export default class ApiGenerator {
     const members: ts.TypeElement[] = Object.keys(props).map((name) => {
       const schema = props[name];
       const isRequired = required && required.includes(name);
-      let type = this.getTypeFromSchema(schema);
+      let type = this.getTypeFromSchema(schema, name);
       if (!isRequired && this.opts.unionUndefined) {
         type = factory.createUnionTypeNode([type, cg.keywordType.undefined]);
       }
@@ -880,7 +963,8 @@ export default class ApiGenerator {
     Object.assign(stub, {
       statements: cg.appendNodes(
         stub.statements,
-        ...[...this.aliases, ...functions]
+        ...[...this.aliases, ...functions],
+        ...this.enumAliases
       ),
     });
 

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1,12 +1,10 @@
-import * as cg from "./tscodegen";
-
-import _, { values } from "lodash";
-import generateServers, { defaultBaseUrl } from "./generateServers";
-import ts, { Statement, factory } from "typescript";
-
-import { OpenAPIV3 } from "openapi-types";
-import { Opts } from ".";
+import _ from "lodash";
+import ts, { factory } from "typescript";
 import path from "path";
+import { OpenAPIV3 } from "openapi-types";
+import * as cg from "./tscodegen";
+import generateServers, { defaultBaseUrl } from "./generateServers";
+import { Opts } from ".";
 import { threadId } from "worker_threads";
 
 export const verbs = [
@@ -447,7 +445,7 @@ export default class ApiGenerator {
       );
     }
     if (schema.enum) {
-      return this.opts.useEnumType && name
+      return this.opts.useEnumType && name && schema.type != "boolean"
         ? this.getTrueEnum(schema, name)
         : this.getTypeFromEnum(schema.enum);
     }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,10 +1,9 @@
 import * as cg from "./tscodegen";
-
 import ApiGenerator from "./generate";
-import { OpenAPIV3 } from "openapi-types";
+import ts from "typescript";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import converter from "swagger2openapi";
-import ts from "typescript";
+import { OpenAPIV3 } from "openapi-types";
 
 export { cg };
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,9 +1,10 @@
 import * as cg from "./tscodegen";
+
 import ApiGenerator from "./generate";
-import ts from "typescript";
+import { OpenAPIV3 } from "openapi-types";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import converter from "swagger2openapi";
-import { OpenAPIV3 } from "openapi-types";
+import ts from "typescript";
 
 export { cg };
 
@@ -12,6 +13,7 @@ export type Opts = {
   exclude?: string[];
   optimistic?: boolean;
   unionUndefined?: boolean;
+  useEnumType?: boolean;
 };
 
 export function generateAst(


### PR DESCRIPTION
# Adds enum generation option

Using the CLI or the API passing the option `--useEnumType` will convert the enums to typescript enums instead of using a union of strings.

This solves #27.

## Why not use components

The components property is only available on the OpenAPI v3. Therefore to make it compatible with the OpenAPI v2 I analyzed the enum values and created the enums based on their title property or in the lack of it the name of the property.

Added some tests and documentation to match this new feature.