### PR TITLE
fix pronunciation YouTube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Since version 3.1.0 you can also use the `--optimistic` flag on the command line
 
 ## About the name
 
-The name comes from a combination of syllables **oa** (OpenAPI) and **ts** (TypeScript) and is [pronounced 🗣](https://youtu.be/chvb-K95rBE) like the Bavarian _O'zapt'is!_ (it's tapped), the famous words that mark the beginning of the Oktoberfest.
+The name comes from a combination of syllables **oa** (OpenAPI) and **ts** (TypeScript) and is [pronounced 🗣](https://www.youtube.com/watch?v=chvb-K95rBE) like the Bavarian _O'zapt'is!_ (it's tapped), the famous words that mark the beginning of the Oktoberfest.
 
 # License
 


### PR DESCRIPTION
When I click on the pronunciation link I'm directed to go to https://youtu.be/chvb-K95rBE, but that page doesn't load for me.

<img width="476" alt="image" src="https://user-images.githubusercontent.com/897017/198054317-f5e393eb-78f6-42a2-b840-b70cc4d9699b.png">

Maybe it's something that's wrong with my network or computer, but the full link works for me https://www.youtube.com/watch?v=chvb-K95rBE