### PR TITLE
Format Path Parameters

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -542,10 +542,10 @@ export function getObjectParameters(
         commaArray,
         commaObject,
       }),
-      QS.space({
+      QS.formSpace({
         spaceDelimited,
       }),
-      QS.pipe({
+      QS.formPipe({
         pipeDelimited,
       }),
       QS.deep({
@@ -568,5 +568,13 @@ export function uploadPng(body?: Blob, opts?: Oazapfts.RequestOpts) {
     ...opts,
     method: "POST",
     body,
+  });
+}
+export function getIssue319ByUserIds(
+  userIds: string[],
+  opts?: Oazapfts.RequestOpts
+) {
+  return oazapfts.fetchText(`/issue319/${QS.simple(userIds)}`, {
+    ...opts,
   });
 }

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -542,10 +542,10 @@ export function getObjectParameters(
         commaArray,
         commaObject,
       }),
-      QS.space({
+      QS.formSpace({
         spaceDelimited,
       }),
-      QS.pipe({
+      QS.formPipe({
         pipeDelimited,
       }),
       QS.deep({
@@ -568,6 +568,14 @@ export function uploadPng(body?: Blob, opts?: Oazapfts.RequestOpts) {
     ...opts,
     method: "POST",
     body,
+  });
+}
+export function getIssue319ByUserIds(
+  userIds: string[],
+  opts?: Oazapfts.RequestOpts
+) {
+  return oazapfts.fetchText(`/issue319/${QS.simple(userIds)}`, {
+    ...opts,
   });
 }
 export enum Status {

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -587,10 +587,10 @@ export function getObjectParameters(
           commaArray,
           commaObject,
         }),
-        QS.space({
+        QS.formSpace({
           spaceDelimited,
         }),
-        QS.pipe({
+        QS.formPipe({
           pipeDelimited,
         }),
         QS.deep({
@@ -615,6 +615,16 @@ export function uploadPng(body?: Blob, opts?: Oazapfts.RequestOpts) {
       ...opts,
       method: "POST",
       body,
+    })
+  );
+}
+export function getIssue319ByUserIds(
+  userIds: string[],
+  opts?: Oazapfts.RequestOpts
+) {
+  return oazapfts.ok(
+    oazapfts.fetchText(`/issue319/${QS.simple(userIds)}`, {
+      ...opts,
     })
   );
 }

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1033,6 +1033,29 @@
           }
         ]
       }
+    },
+    "/issue319/{userIds}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "userIds",
+            "in": "path",
+            "explode": false,
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oazapfts",
-  "version": "4.2.0",
+  "version": "4.2.1-formatted-path-params.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oazapfts",
-      "version": "4.2.0",
+      "version": "4.2.1-formatted-path-params.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oazapfts",
-  "version": "4.2.0",
+  "version": "4.2.1-formatted-path-params.1",
   "description": "OpenApi TypeScript client generator",
   "main": "lib/index.js",
   "bin": {

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -1,4 +1,4 @@
-import ApiGenerator, { getOperationName } from "./generate";
+import ApiGenerator, { getOperationName, getFormatter } from "./generate";
 import { printAst } from "./index";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import { OpenAPIV3 } from "openapi-types";
@@ -139,3 +139,10 @@ describe("generate with const", () => {
     expect(oneLine).toContain(constTypeDefinition);
   });
 });
+
+// // https://spec.openapis.org/oas/v3.0.3#style-examples
+// describe('getFormatter', () => {
+//   it('formats correctly', () => {
+//     const formatter = getFormatter()
+//   })
+// })

--- a/src/runtime/query.test.ts
+++ b/src/runtime/query.test.ts
@@ -4,11 +4,17 @@ describe("delimited", () => {
   it("should use commas", () => {
     expect(qs.form({ id: [3, 4, 5] })).toEqual("id=3,4,5");
   });
+  it("should use pipes for form", () => {
+    expect(qs.formPipe({ id: [3, 4, 5] })).toEqual("id=3|4|5");
+  });
+  it("should use spaces for form", () => {
+    expect(qs.formSpace({ id: [3, 4, 5] })).toEqual("id=3%204%205");
+  });
   it("should use pipes", () => {
-    expect(qs.pipe({ id: [3, 4, 5] })).toEqual("id=3|4|5");
+    expect(qs.pipe([3, 4, 5])).toEqual("3|4|5");
   });
   it("should use spaces", () => {
-    expect(qs.space({ id: [3, 4, 5] })).toEqual("id=3%204%205");
+    expect(qs.space([3, 4, 5])).toEqual("3%204%205");
   });
   it("should enumerate entries", () => {
     expect(qs.form({ author: { firstName: "Felix", role: "admin" } })).toEqual(

--- a/src/runtime/query.ts
+++ b/src/runtime/query.ts
@@ -1,4 +1,9 @@
-import { encode, delimited, encodeReserved } from "./util";
+import {
+  encode,
+  form as encodeForm,
+  simple as encodeSimple,
+  encodeReserved,
+} from "./util";
 
 /**
  * Join params using an ampersand and prepends a questionmark if not empty.
@@ -61,6 +66,9 @@ export function explode(
     .join("&");
 }
 
-export const form = delimited();
-export const pipe = delimited("|");
-export const space = delimited("%20");
+export const form = encodeForm();
+export const formPipe = encodeForm("|");
+export const formSpace = encodeForm("%20");
+export const simple = encodeSimple();
+export const pipe = encodeSimple("|");
+export const space = encodeSimple("%20");


### PR DESCRIPTION
This aims to provide a non-breaking fix for https://github.com/cellular/oazapfts/issues/319 

But while working at it I realized that all the parameter formatting currently aims at query-strings and implicitly used defaults for them etc. 

I currently tend to not actually merge this but instead rework the parameter serialization again (flashback to https://github.com/cellular/oazapfts/pull/280) to be spec compliant for query, path, cookie and header parameters.

