### PR TITLE
Avoid name conflicts between types and enums

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -54,6 +54,7 @@ export type User = {
   password?: string;
   phone?: string;
   userStatus?: number;
+  category?: "rich" | "wealthy" | "poor";
 };
 export type Schema = string;
 export type Schema2 = number;

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -54,6 +54,7 @@ export type User = {
   password?: string;
   phone?: string;
   userStatus?: number;
+  category?: Category2;
 };
 export type Schema = string;
 export type Schema2 = number;
@@ -584,4 +585,9 @@ export enum Status2 {
   Placed = "Placed",
   Approved = "Approved",
   Delivered = "Delivered",
+}
+export enum Category2 {
+  Rich = "Rich",
+  Wealthy = "Wealthy",
+  Poor = "Poor",
 }

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -54,6 +54,7 @@ export type User = {
   password?: string;
   phone?: string;
   userStatus?: number;
+  category?: "rich" | "wealthy" | "poor";
 };
 export type Schema = string;
 export type Schema2 = number;

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1096,6 +1096,11 @@
             "type": "integer",
             "description": "User Status",
             "format": "int32"
+          },
+          "category": {
+            "type": "string",
+            "description": "user category in the store",
+            "enum": ["rich", "wealthy", "poor"]
           }
         },
         "xml": {

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -85,6 +85,21 @@ describe("generate", () => {
 
     expect(oneLine).toContain(sameNameDefinition);
   });
+
+  it("should avoid name conflicts between types and enums", async () => {
+    const api = printAst(
+      new ApiGenerator(spec.petstore, { useEnumType: true }).generateApi()
+    );
+    const oneLine = api.replace(/\s+/g, " ");
+
+    // Type Category is defined as `Category`
+    const typeDefinition = `export type Category = { id?: number; name?: string; };`;
+    expect(oneLine).toContain(typeDefinition);
+
+    // Enum Category is defined as `Category2` to avoid name conflict with type Category
+    const enumDefinition = `export enum Category2 { Rich = "Rich", Wealthy = "Wealthy", Poor = "Poor" }`;
+    expect(oneLine).toContain(enumDefinition);
+  });
 });
 
 describe("generate with application/geo+json", () => {

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -96,6 +96,10 @@ describe("generate", () => {
     const typeDefinition = `export type Category = { id?: number; name?: string; };`;
     expect(oneLine).toContain(typeDefinition);
 
+    // Enum Category is also defined as `Category` which would be a conflict to type `Category`
+    const conflictingEnumDefinition = `export enum Category { Rich = "Rich", Wealthy = "Wealthy", Poor = "Poor" }`;
+    expect(oneLine).not.toContain(conflictingEnumDefinition);
+
     // Enum Category is defined as `Category2` to avoid name conflict with type Category
     const enumDefinition = `export enum Category2 { Rich = "Rich", Wealthy = "Wealthy", Poor = "Poor" }`;
     expect(oneLine).toContain(enumDefinition);

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -209,7 +209,6 @@ export default class ApiGenerator {
   aliases: ts.TypeAliasDeclaration[] = [];
 
   enumAliases: ts.Statement[] = [];
-  typeEnumAliases: Record<string, number> = {};
   enumRefs: Record<string, { values: string; type: ts.TypeReferenceNode }> = {};
 
   // Collect the types of all referenced schemas so we can export them later
@@ -263,21 +262,12 @@ export default class ApiGenerator {
   }
 
   getEnumUniqueAlias(name: string, values: string) {
-    // If the enum does not exist
-    if (!this.enumRefs[name]) {
-      this.typeEnumAliases[name] = 1;
-      return name;
-
-      // If enum name already exists and have the same values
-    } else if (this.enumRefs[name] && this.enumRefs[name].values == values) {
-      return name;
-
-      // If the already exists but has a different value: eg Status2
-    } else {
-      this.typeEnumAliases[name] += 1;
-      name += this.typeEnumAliases[name];
+    // If enum name already exists and have the same values
+    if (this.enumRefs[name] && this.enumRefs[name].values == values) {
       return name;
     }
+
+    return this.getUniqueAlias(name);
   }
 
   getRefBasename(ref: string): string {


### PR DESCRIPTION
Currently, the generator separately avoids name conflicts between types on the one hand and enums on the other hand. Interdependend name conflicts between types and enums are still possible. This PR attempts to fix this.

Besides that, thanks for your great tool!